### PR TITLE
Implements the service of the 24h clock of the CIA. This make the GEO…

### DIFF
--- a/vhdl/iomapper.vhdl
+++ b/vhdl/iomapper.vhdl
@@ -454,7 +454,7 @@ architecture behavioral of iomapper is
   signal restore_down_count : unsigned(7 downto 0) := x"00";
   
   signal clock50hz : std_logic := '1';
-  constant divisor50hz : integer := 640000; -- 64MHz/50Hz/2;
+  constant divisor50hz : integer := 480000; -- 48MHz/50Hz/2;
   signal counter50hz : integer := 0;
   
   signal cia1cs : std_logic;


### PR DESCRIPTION
…S clock run and also enables TI$/SLEEP in later ROM versions. This related to github Issue #1.

This doesn't implement the alarm behaviour and doesn't consider specifics of the CIA BCD register use for start/stop the service.