### PR TITLE
Fix ROM protection default and traps

### DIFF
--- a/src/kickstart.a65
+++ b/src/kickstart.a65
@@ -1974,8 +1974,8 @@ g61:		sta $0800,x
 		sta $d059
 
 		; write protect ROM RAM
-		lda #$02
-		tsb hypervisor_hardware_virtualisation
+		lda #$04
+		tsb hypervisor_feature_enables
 
 		jsr task_set_c64_memorymap
 		jsr task_set_pc_to_reset_vector

--- a/src/kickstart_mem.a65
+++ b/src/kickstart_mem.a65
@@ -112,11 +112,12 @@ memory_trap_table:
 	.word invalid_subfunction
 
 rom_writeenable:
-	lda #$02
+	lda #$04
 	trb hypervisor_feature_enables
 	jmp return_from_trap_with_success
 
 rom_writeprotect:
-	lda #$02
+	lda #$04
 	tsb hypervisor_feature_enables
-	jmp return_from_trap_with_success	
+	jmp return_from_trap_with_success
+


### PR DESCRIPTION
Please review these changes if it's OK. It seems to solve the problem for default ROM protection (should be on by default), tested on the board. Though, I haven't tested the traps themselves, just seems to be logical to have these changes. Hopefully it's OK.