### PR TITLE
add miso2_in to nexys4 target

### DIFF
--- a/src/vhdl/nexys4.vhdl
+++ b/src/vhdl/nexys4.vhdl
@@ -446,6 +446,7 @@ begin
       sclk_o => sdClock,
       mosi_o => sdMOSI,
       miso_i => sdMISO,
+      miso2_i => '1',
 
       aclMISO => aclMISO,
       aclMOSI => aclMOSI,


### PR DESCRIPTION
Fixes build failure for nexys4 (non-ddr).

Looks like nexys4.vhdl was overlooked in commit f7dbfec54 when support/stubs for secondary SD interface were added to all platforms.

I don't have the older nexys4 so I'm unable to test on actual hardware but the change seems straightforward.
