### PR TITLE
Let `vivado_wrapper` take a custom Vivado install path

### DIFF
--- a/vivado_wrapper
+++ b/vivado_wrapper
@@ -1,5 +1,10 @@
 #!/bin/bash
-vivadodir=`ls -1d /opt/Xilinx/Vivado/* | tail -1`
-. ${vivadodir}/settings64.sh
+
+# Check if VIVADODIR is empty or undefined and detect version instead
+if [ -z "$VIVADODIR" ]; then
+    VIVADODIR=`ls -1d /opt/Xilinx/Vivado/* | tail -1`
+fi
+
+. ${VIVADODIR}/settings64.sh
 echo vivado $*
 vivado $*


### PR DESCRIPTION
Addresses #85
The `vivado_wrapper` script will accept a custom Vivado path through the `VIVADODIR` variable which can be set through `make`.

This should mitigate having to symlink Vivado to `/opt/Xilinx/Vivado/` or modify the wrapper for custom installations.