### PR TITLE
auto compile and use the ACME compiler

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "src/mega65-libc"]
 	path = src/mega65-libc
 	url = https://github.com/MEGA65/mega65-libc.git
+[submodule "src/tools/acme"]
+	path = src/tools/acme
+	url = https://github.com/MEGA65/acme.git

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ OPHIS=	Ophis/bin/ophis
 OPHISOPT=	-4
 OPHIS_MON= Ophis/bin/ophis -c
 
-ACME=acme
+#ACME=acme
+ACME=src/tools/acme/src/acme
 
 VIVADO=	./vivado_wrapper
 
@@ -97,6 +98,11 @@ endif
 $(OPHIS):
 	git submodule init
 	git submodule update
+
+$(ACME):
+	git submodule init
+	git submodule update
+	( cd src/tools/acme/src && make )
 
 $(GHDL):
 	git submodule init

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,15 @@ OPHIS=	Ophis/bin/ophis
 OPHISOPT=	-4
 OPHIS_MON= Ophis/bin/ophis -c
 
-#ACME=acme
-ACME=src/tools/acme/src/acme
+
+ifdef USE_LOCAL_ACME
+	# use locally installed binary (requires 'acme' to be in the $PATH)
+	ACME=	acme
+else
+	# use the binary built from the submodule
+	ACME=src/tools/acme/src/acme
+endif
+
 
 VIVADO=	./vivado_wrapper
 
@@ -100,9 +107,16 @@ $(OPHIS):
 	git submodule update
 
 $(ACME):
+	$(warning =============================================================)
+	$(warning ~~~~~~~~~~~~~~~~> Making: $@)
 	git submodule init
 	git submodule update
-	( cd src/tools/acme/src && make )
+ifdef USE_LOCAL_ACME
+	echo "NOTE: Using local installed ACME because USE_LOCAL_ACME=1."
+else
+	( cd src/tools/acme/src && make -j 8 )
+endif
+
 
 $(GHDL):
 	git submodule init


### PR DESCRIPTION
this was previously PR#270 (now abandoned)

this PR has changes applied to a feature-branch instead of on top of Pauls 138.

To do:
- update Makefile, possibly add USE_LOCAL_ACME
- remove Kickass
- etc