### PR TITLE
builds now, removed ethertest.prg from Makefile, #273

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,7 @@ SDCARD_DIR=	sdcard-files
 #
 # NOTE: that all files listed below will be embedded within the "MEGA65.D81".
 #
-UTILITIES=	$(UTILDIR)/ethertest.prg \
-		$(UTILDIR)/etherload.prg \
+UTILITIES=	$(UTILDIR)/etherload.prg \
 		$(UTILDIR)/test01prg.prg \
 		$(UTILDIR)/c65test02prg.prg \
 		$(UTILDIR)/c65-rom-910111-fastload-patch.prg \


### PR DESCRIPTION
as the source-code for this build artefact does not exist anymore.

this PR should enable a compile from a clean checkout