### PR TITLE
fix version.sh script, mistake corrected, #291

### DIFF
--- a/src/version.sh
+++ b/src/version.sh
@@ -8,7 +8,7 @@ branch=`git rev-parse --abbrev-ref HEAD`
 #
 # if branchname is long, just use the first X-chars and last X-chars, ie "abcde...vwxyz"
 branchlen=$(( ${#branch} ))
-echo ${branchlen}
+#echo ${branchlen}
 #
 if [ ${branchlen} -gt 13 ] ; then
   branch_abcde=${branch:0:5}
@@ -36,7 +36,7 @@ datetime=`date +%Y%m%d.%H`
 
 # ###############################
 # get incrememting number (number of commits since branching from branch "ghdl-crash-20200604")
-num_commits="$(git log upstream/ghdl-crash-20200604..138-hdmi-audio-27mhz --oneline | wc -l)"
+num_commits="$(git log ghdl-crash-20200604..138-hdmi-audio-27mhz --oneline | wc -l)"
 #echo ${num_commits}
 
 


### PR DESCRIPTION
i used the branchname "origin/branchname" but this does not exist in repo.
needed to use just "branchname"

also removed a debug printline

also NOTE that we are waiting on Falk to update the Jenkins-script to:
```
git checkout branchname
```
opposed to using the Jenkins feature to checkout the commit causing detached head.