### PR TITLE
#372 sid names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,10 +113,10 @@ $(SDCARD_DIR)/FREEZER.M65 $(SDCARD_DIR)/AUDIOMIX.M65 $(SDCARD_DIR)/C64THUMB.M65 
 	git submodule init
 	git submodule update
 	( cd src/mega65-freezemenu && make FREEZER.M65 AUDIOMIX.M65 C64THUMB.M65 C65THUMB.M65 USE_LOCAL_CC65=$(USE_LOCAL_CC65))
-	cp src/mega65-freezemenu/FREEZER.M65 $(SDCARD_DIR)
-	cp src/mega65-freezemenu/AUDIOMIX.M65 $(SDCARD_DIR)
-	cp src/mega65-freezemenu/C64THUMB.M65 $(SDCARD_DIR)
-	cp src/mega65-freezemenu/C65THUMB.M65 $(SDCARD_DIR)
+	cp src/mega65-freezemenu/FREEZER.M65 $(SDCARD_DIR)/
+	cp src/mega65-freezemenu/AUDIOMIX.M65 $(SDCARD_DIR)/
+	cp src/mega65-freezemenu/C64THUMB.M65 $(SDCARD_DIR)/
+	cp src/mega65-freezemenu/C65THUMB.M65 $(SDCARD_DIR)/
 
 $(CBMCONVERT):
 	git submodule init

--- a/iomap.txt
+++ b/iomap.txt
@@ -1,3 +1,4 @@
+GS $00 ETHCOMMAND:STOPTX Immediately stop transmitting the current ethernet frame.  Will cause a partially sent frame to be received, most likely resulting in the loss of that frame.  
 C64 $0000000 6510/45GS10 CPU port DDR
 C64 $0000000 CPU:PORTDDR 6510/45GS10 CPU port DDR
 C64 $0000001 6510/45GS10 CPU port data
@@ -13,7 +14,6 @@ C65 $0032000-$0035FFF - 8KB C65 BASIC ROM
 C65 $0038000-$003BFFF - 8KB C65 BASIC GRAPHICS ROM
 C65 $003C000-$003CFFF - 4KB C65 KERNAL/INTERFACE ROM
 C65 $003E000-$003FFFF - 8KB C65 KERNAL ROM
-GS $00 ETHCOMMAND:STOPTX Immediately stop transmitting the current ethernet frame.  Will cause a partially sent frame to be received, most likely resulting in the loss of that frame.  
 GS $01 ETHCOMMAND:STARTTX Transmit packet
 GS $4000000 - $7FFFFFF Slow Device memory (64MB)
 GS $4000000 - $7FFFFFF SUMMARY:SLOWDEV Slow Device memory (64MB)
@@ -39,6 +39,7 @@ GS $7010009 - Directly read upper 8 cartridge address data lines.
 GS $7FEFFFF.0 Enable/disable SFX cartridge emulation
 GS $8000000 - $FEFFFFF Slow Device memory (127MB)
 GS $8000000 - $FEFFFFF SUMMARY:SLOWDEV Slow Device memory (127MB)
+GS $D0 ETHCOMMAND:RXNORMAL Disable the effects of RXONLYONE
 C64 $D000 VIC-II:S0X sprite 0 horizontal position
 C64 $D001 VIC-II:S0Y sprite 0 vertical position
 C64 $D002 VIC-II:S1X sprite 1 horizontal position
@@ -56,35 +57,35 @@ C64 $D00D VIC-II:S6Y sprite 6 vertical position
 C64 $D00E VIC-II:S7X sprite 7 horizontal position
 C64 $D00F VIC-II:S7Y sprite 7 vertical position
 C64 $D010 VIC-II:SXMSB sprite horizontal position MSBs
+C64 $D011 VIC-II control register
 C64 $D011.2-0 VIC-II:YSCL 24/25 vertical smooth scroll
 C64 $D011.3 VIC-II:RSEL 24/25 row select
 C64 $D011.4 VIC-II:BLNK disable display
 C64 $D011.5 VIC-II:BMM bitmap mode
 C64 $D011.6 VIC-II:ECM extended background mode
 C64 $D011.7 VIC-II:RC raster compare bit 8
-C64 $D011 VIC-II control register
 C64 $D012 VIC-II:RC raster compare bits 0 to 7
 C64 $D013 VIC-II:LPX Coarse horizontal beam position (was lightpen X)
 C64 $D014 VIC-II:LPY Coarse vertical beam position (was lightpen Y)
 C64 $D015 VIC-II:SE sprite enable bits
+C64 $D016 VIC-II control register
 C64 $D016.2-0 VIC-II:XSCL horizontal smooth scroll
 C64 $D016.3 VIC-II:CSEL 38/40 column select
 C64 $D016.4 VIC-II:MCM Multi-colour mode
 C64 $D016.5 VIC-II:RST Disables video output on MAX Machine(tm) VIC-II 6566.  Ignored on normal C64s and the MEGA65
-C64 $D016 VIC-II control register
 C64 $D017 VIC-II:SEXY sprite vertical expansion enable bits
+C64 $D018 VIC-II RAM addresses
 C64 $D018.3-1 VIC-II:CB character set address location ($\times$ 1KiB)
 C64 $D018.7-4 VIC-II:VS screen address ($\times$ 1KiB)
-C64 $D018 VIC-II RAM addresses
+C64 $D019 VIC-II IRQ control
 C64 $D019.0 VIC-II:RIRQ raster compare indicate or acknowledge
 C64 $D019.1 VIC-II:ISBC sprite:bitmap collision indicate or acknowledge
 C64 $D019.2 VIC-II:ISSC sprite:sprite collision indicate or acknowledge
 C64 $D019.3 VIC-II:ILP light pen indicate or acknowledge
-C64 $D019 VIC-II IRQ control
+C64 $D01A compatibility IRQ mask bits
 C64 $D01A.0 VIC-II:MRIRQ mask raster IRQ
 C64 $D01A.1 VIC-II:MISBC mask sprite:bitmap collision IRQ
 C64 $D01A.2 VIC-II:MISSC mask sprite:sprite collision IRQ
-C64 $D01A compatibility IRQ mask bits
 C64 $D01B VIC-II:BSP sprite background priority bits
 C64 $D01C VIC-II:SCM sprite multicolour enable bits
 C64 $D01D VIC-II:SEXX sprite horizontal expansion enable bits
@@ -92,31 +93,31 @@ C64 $D01E sprite/sprite collissions
 C64 $D01E VIC-II:SSC sprite/sprite collision indicate bits
 C64 $D01F sprite/foreground collissions
 C64 $D01F VIC-II:SBC sprite/foreground collision indicate bits
+C64 $D020 Border colour
 C64 $D020.3-0 VIC-II:BORDERCOL display border colour (16 colour)
 C65 $D020.7-0 VIC-III:BORDERCOL display border colour (256 colour)
 GS $D020.7-0 VIC-IV:BORDERCOL display border colour (256 colour)
-C64 $D020 Border colour
+C64 $D021 Screen colour
 C64 $D021.3-0 VIC-II:SCREENCOL screen colour (16 colour)
 C65 $D021.7-0 VIC-III:SCREENCOL screen colour (256 colour)
 GS $D021.7-0 VIC-IV:SCREENCOL screen colour (256 colour)
-C64 $D021 Screen colour
+C64 $D022 VIC-II multi-colour 1
 C64 $D022.3-0 VIC-II:MC1 multi-colour 1 (16 colour)
 C65 $D022.7-0 VIC-III:MC1 multi-colour 1 (256 colour)
 GS $D022.7-0 VIC-IV:MC1 multi-colour 1 (256 colour)
-C64 $D022 VIC-II multi-colour 1
+C64 $D023 VIC-II multi-colour 2
 C64 $D023.3-0 VIC-II:MC2 multi-colour 2 (16 colour)
 C65 $D023.7-0 VIC-III:MC2 multi-colour 2 (256 colour)
 GS $D023.7-0 VIC-IV:MC2 multi-colour 2 (256 colour)
-C64 $D023 VIC-II multi-colour 2
+C64 $D024 VIC-II multi-colour 3
 C64 $D024.3-0 VIC-II:MC3 multi-colour 3 (16 colour)
 C65 $D024.7-0 VIC-III:MC3 multi-colour 3 (256 colour)
 GS $D024.7-0 VIC-IV:MC3 multi-colour 3 (256 colour)
-C64 $D024 VIC-II multi-colour 3
-C65 $D025 VIC-III:SPRMC0 Sprite multi-colour 0 (8-bit for selection of any palette colour)
 C64 $D025 VIC-II:SPRMC0 Sprite multi-colour 0
+C65 $D025 VIC-III:SPRMC0 Sprite multi-colour 0 (8-bit for selection of any palette colour)
 GS $D025 VIC-IV:SPRMC0 Sprite multi-colour 0 (8-bit for selection of any palette colour)
-C65 $D026 VIC-III:SPRMC1 Sprite multi-colour 1 (8-bit for selection of any palette colour)
 C64 $D026 VIC-II:SPRMC1 Sprite multi-colour 1
+C65 $D026 VIC-III:SPRMC1 Sprite multi-colour 1 (8-bit for selection of any palette colour)
 GS $D026 VIC-IV:SPRMC1 Sprite multi-colour 1 (8-bit for selection of any palette colour)
 C64 $D027 VIC-II:SPR0COL sprite 0 colour / 16-colour sprite transparency colour (lower nybl)
 C64 $D028 VIC-II:SPR1COL sprite 1 colour / 16-colour sprite transparency colour (lower nybl)
@@ -131,6 +132,8 @@ C65 $D02F VIC-III:KEY Write $A5 then $96 to enable C65/VIC-III IO registers
 GS $D02F VIC-IV:KEY Write $45 then $54 to map 45E100 ethernet controller buffers to $D000-$DFFF
 GS $D02F VIC-IV:KEY Write $47 then $53 to enable C65GS/VIC-IV IO registers
 C65 $D02F Write anything else to return to C64/VIC-II IO map
+C64 $D030 SUMMARY: C128 2MHz emulation
+C65 $D030 SUMMARY:VIC-III Control Register A
 C64 $D030.0 VIC-II:C128FAST 2MHz select (for C128 2MHz emulation)
 C65 $D030.0 VIC-III:CRAM2K Map 2nd KB of colour RAM @ $DC00-$DFFF
 C65 $D030.1 VIC-III:EXTSYNC Enable external video sync (genlock input)
@@ -140,8 +143,7 @@ C65 $D030.4 VIC-III:ROMA Map C65 ROM @ $A000
 C65 $D030.5 VIC-III:ROMC Map C65 ROM @ $C000
 C65 $D030.6 VIC-III:CROM9 Select between C64 and C65 charset.
 C65 $D030.7 VIC-III:ROME Map C65 ROM @ $E000
-C64 $D030 SUMMARY: C128 2MHz emulation
-C65 $D030 SUMMARY:VIC-III Control Register A
+C65 $D031 SUMMARY:VIC-III Control Register B
 C65 $D031.0 VIC-III:INT Enable VIC-III interlaced mode
 C65 $D031.1 VIC-III:MONO Enable VIC-III MONO video output (not implemented)
 C65 $D031.2 VIC-III:H1280 Enable 1280 horizontal pixels (not implemented)
@@ -150,33 +152,32 @@ C65 $D031.4 VIC-III:BPM Bit-Plane Mode
 C65 $D031.5 VIC-III:ATTR Enable extended attributes and 8 bit colour entries
 C65 $D031.6 VIC-III:FAST Enable C65 FAST mode (~3.5MHz)
 C65 $D031.7 VIC-III:H640 Enable C64 640 horizontal pixels / 80 column mode
-C65 $D031 SUMMARY:VIC-III Control Register B
 C65 $D032 - Bitplane enable bits
-C65 $D033.1-3 VIC-III:B0ADEVN - Bitplane 0 address, even lines
-C65 $D033.5-7 VIC-III:B0ADODD - Bitplane 0 address, odd lines
 C65 $D033 - Bitplane 0 address
 C65 $D033-$D03A - VIC-III Bitplane addresses
+C65 $D033.1-3 VIC-III:B0ADEVN - Bitplane 0 address, even lines
+C65 $D033.5-7 VIC-III:B0ADODD - Bitplane 0 address, odd lines
+C65 $D034 - Bitplane 1 address
 C65 $D034.1-3 VIC-III:B1ADEVN - Bitplane 1 address, even lines
 C65 $D034.5-7 VIC-III:B1ADODD - Bitplane 1 address, odd lines
-C65 $D034 - Bitplane 1 address
+C65 $D035 - Bitplane 2 address
 C65 $D035.1-3 VIC-III:B2ADEVN - Bitplane 2 address, even lines
 C65 $D035.5-7 VIC-III:B2ADODD - Bitplane 2 address, odd lines
-C65 $D035 - Bitplane 2 address
+C65 $D036 - Bitplane 3 address
 C65 $D036.1-3 VIC-III:B3ADEVN - Bitplane 3 address, even lines
 C65 $D036.5-7 VIC-III:B3ADODD - Bitplane 3 address, odd lines
-C65 $D036 - Bitplane 3 address
+C65 $D037 - Bitplane 4 address
 C65 $D037.1-3 VIC-III:B4ADEVN - Bitplane 4 address, even lines
 C65 $D037.5-7 VIC-III:B4ADODD - Bitplane 4 address, odd lines
-C65 $D037 - Bitplane 4 address
+C65 $D038 - Bitplane 5 address
 C65 $D038.1-3 VIC-III:B5ADEVN - Bitplane 5 address, even lines
 C65 $D038.5-7 VIC-III:B5ADODD - Bitplane 5 address, odd lines
-C65 $D038 - Bitplane 5 address
+C65 $D039 - Bitplane 6 address
 C65 $D039.1-3 VIC-III:B6ADEVN - Bitplane 6 address, even lines
 C65 $D039.5-7 VIC-III:B6ADODD - Bitplane 6 address, odd lines
-C65 $D039 - Bitplane 6 address
+C65 $D03A - Bitplane 7 address
 C65 $D03A.1-3 VIC-III:B7ADEVN - Bitplane 7 address, even lines
 C65 $D03A.5-7 VIC-III:B7ADODD - Bitplane 7 address, odd lines
-C65 $D03A - Bitplane 7 address
 C65 $D03B - Set bits to NOT bitplane contents
 C65 $D03B VIC-III:BPCOMP Complement bitplane flags
 C65 $D03C - Bitplane X
@@ -209,10 +210,13 @@ GS $D04F.3-0 VIC-IV:TEXTYPOS Character generator vertical position
 GS $D04F.7-4 VIC-IV:SPRTILEN Sprite 7-4 horizontal tile enables
 GS $D050 VIC-IV:XPOS Read horizontal raster scan position LSB
 GS $D051.0-5 VIC-IV:XPOS Read horizontal raster scan position MSB
+GS $D051.6 VIC-IV:DBLRR When set, the Raster Rewrite Buffer is only updated every 2nd raster line, limiting resolution to V200, but allowing more cycles for Raster-Rewrite actions.
 GS $D051.7 VIC-IV:NORRDEL When clear, raster rewrite double buffering is used
 GS $D052 VIC-IV:FNRASTER Read physical raster position
 GS $D053.0-2 VIC-IV:FNRASTER Read physical raster position
+GS $D053.6 VIC-IV:SHDEMU Enable simulated shadow-mask (PALEMU must also be enabled)
 GS $D053.7 VIC-IV:FNRST Raster compare source (0=VIC-IV fine raster, 1=VIC-II raster)
+GS $D054 SUMMARY:VIC-IV Control register C
 GS $D054.0 VIC-IV:CHR16 enable 16-bit character numbers (two screen bytes per character)
 GS $D054.1 VIC-IV:FCLRLO enable full-colour mode for character numbers <=$FF
 GS $D054.2 VIC-IV:FCLRHI enable full-colour mode for character numbers >$FF
@@ -221,7 +225,6 @@ GS $D054.4 VIC-IV:SPR640 Sprite H640 enable;
 GS $D054.5 VIC-IV:PALEMU video output pal simulation
 GS $D054.6 VIC-IV:VFAST C65GS FAST mode (48MHz)
 GS $D054.7 VIC-IV:ALPHEN Alpha compositor enable
-GS $D054 SUMMARY:VIC-IV Control register C
 GS $D055 VIC-IV:SPRHGTEN sprite extended height enable (one bit per sprite)
 GS $D056 VIC-IV:SPRHGHT Sprite extended height size (sprite pixels high)
 GS $D057 VIC-IV:SPRX64EN Sprite extended width enables (8 bytes per sprite row = 64 pixels wide for normal sprites or 16 pixels wide for 16-colour sprite mode)
@@ -258,11 +261,11 @@ GS $D06E.7 VIC-IV:SPRPTR16 16-bit sprite pointer mode (allows sprites to be loca
 GS $D06F.5-0 VIC-IV:RASLINE0 first VIC-II raster line
 GS $D06F.6 VIC-IV:VGAHDTV Select more VGA-compatible mode if set, instead of HDMI/HDTV VIC-II cycle-exact frame timing. May help to produce a functional display on older VGA monitors.
 GS $D06F.7 VIC-IV:PALNTSC NTSC emulation mode (max raster = 262)
+GS $D070 NONE:VIC-IV palette bank selection
 GS $D070.1-0 VIC-IV:ABTPALSEL VIC-IV bitmap/text palette bank (alternate palette)
 GS $D070.3-2 VIC-IV:SPRPALSEL sprite palette bank
 GS $D070.5-4 VIC-IV:BTPALSEL bitmap/text palette bank
 GS $D070.7-6 VIC-IV:MAPEDPAL palette bank mapped at $D100-$D3FF
-GS $D070 NONE:VIC-IV palette bank selection
 GS $D071 VIC-IV:BP16ENS VIC-IV 16-colour bitplane enable flags
 GS $D072 VIC-IV:SPRYADJ Sprite Y position adjustment
 GS $D073.0-3 VIC-IV:ALPHADELAY Alpha delay for compositor
@@ -279,7 +282,8 @@ GS $D07A.4-5 VIC-IV:RESERVED
 GS $D07A.6 VIC-IV:EXTIRQS Enable additional IRQ sources, e.g., raster X position.
 GS $D07A.7 VIC-IV:FNRSTCMP Raster compare is in physical rasters if set, or VIC-II raster if clear
 GS $D07B VIC-IV:Number of text rows to display
-GS $D07C.0-3 VIC-IV:RESERVED UNUSED BITS
+GS $D07C.0-2 VIC-IV:BITPBANK Set which 128KB bank bitplanes
+GS $D07C.3 VIC-IV:RESERVED Unused bit. Leave zero.
 GS $D07C.4 VIC-IV:HSYNCP hsync polarity
 GS $D07C.5 VIC-IV:VSYNCP vsync polarity
 GS $D07C.6-7 VIC-IV:RESERVED UNUSED BITS
@@ -288,13 +292,14 @@ GS $D07E DEBUG:DEBUGY VIC-IV debug Y position (LSB)
 GS $D07F.0-3 DEBUG:DEBUGX VIC-IV debug X position (MSB)
 GS $D07F.4-7 DEBUG:DEBUGY VIC-IV debug Y position (MSB)
 GS $D07F.7 DEBUG:DEBUGOOF VIC-IV debug out-of-frame signal enable
+C65 $D080 - F011 FDC control
 C65 $D080.0-2 FDC:DS Drive select (0 to 7). Internal drive is 0. Second floppy drive on internal cable is 1. Other values reserved for C1565 external drive interface.
 C65 $D080.3 FDC:SIDE Directly controls the SIDE signal to the floppy drive, i.e., selecting which side of the media is active.
 C65 $D080.4 FDC:SWAP Swap upper and lower halves of data buffer (i.e. invert bit 8 of the sector buffer)
 C65 $D080.5 FDC:MOTOR Activates drive motor and LED (unless LED signal is also set, causing the drive LED to blink)
 C65 $D080.6 FDC:LED Drive LED blinks when set
 C65 $D080.7 FDC:IRQ When set, enables interrupts to occur. Clearing clears any pending interrupt and disables interrupts until set again.
-C65 $D080 - F011 FDC control
+C65 $D081 FDC:COMMAND F011 FDC command register
 C65 $D081.0 FDC:NOBUF Reset the sector buffer read/write pointers
 C65 $D081.1 FDC:ALT Selects alternate DPLL read recovery method (not implemented)
 C65 $D081.2 FDC:ALGO Selects reading and writing algorithm (currently ignored).
@@ -303,7 +308,7 @@ C65 $D081.4 FDC:STEP Writing 1 causes the head to step in the indicated directio
 C65 $D081.5 FDC:FREE Command is a free-format (low level) operation
 C65 $D081.6 FDC:RDCMD Command is a read operation if set
 C65 $D081.7 FDC:WRCMD Command is a write operation if set
-C65 $D081 FDC:COMMAND F011 FDC command register
+C65 $D082 - F011 FDC Status A port (read only)
 C65 $D082.0 FDC:TK0 F011 Head is over track 0 flag (read only)
 C65 $D082.1 FDC:PROT F011 Disk write protect flag (read only)
 C65 $D082.2 FDC:LOST F011 LOST flag (data was lost during transfer, i.e., CPU did not read data fast enough) (read only)
@@ -312,7 +317,7 @@ C65 $D082.4 FDC:RNF F011 FDC Request Not Found (RNF), i.e., a sector read or wri
 C65 $D082.5 FDC:EQ F011 FDC CPU and disk pointers to sector buffer are equal, indicating that the sector buffer is either full or empty. (read only)
 C65 $D082.6 FDC:DRQ F011 FDC DRQ flag (one or more bytes of data are ready) (read only)
 C65 $D082.7 FDC:BUSY F011 FDC busy flag (command is being executed) (read only)
-C65 $D082 - F011 FDC Status A port (read only)
+C65 $D083 - F011 FDC Status B port (read only)
 C65 $D083.0 FDC:DSKCHG F011 disk change sense (read only)
 C65 $D083.1 FDC:IRQ The floppy controller has generated an interrupt (read only). Note that interrupts are not currently implemented on the 45GS27.
 C65 $D083.2 FDC:INDEX F011 Index hole sense (read only)
@@ -321,7 +326,6 @@ C65 $D083.4 FDC:WGATE F011 write gate flag. Indicates that the drive is currentl
 C65 $D083.5 FDC:RUN F011 Successive match.  A synonym of RDREQ on the 45IO47 (read only)
 C65 $D083.6 FDC:WTREQ F011 Write Request flag, i.e., the requested sector was found during a write operation (read only)
 C65 $D083.7 FDC:RDREQ F011 Read Request flag, i.e., the requested sector was found during a read operation (read only)
-C65 $D083 - F011 FDC Status B port (read only)
 C65 $D084 FDC:TRACK F011 FDC track selection register
 C65 $D085 FDC:SECTOR F011 FDC sector selection register
 C65 $D086 FDC:SIDE F011 FDC side selection register
@@ -344,6 +348,7 @@ GS $D0E0.4 Enable loopback mode
 GS $D0E0.5 Buffered UART master RX buffer high-water IRQ enable
 GS $D0E0.6 Buffered UART master TX queue low-water IRQ enable
 GS $D0E0.7 Buffered UART master IRQ enable
+GS $D0E1 Buffered UART Status register / interrupt select register
 GS $D0E1.0 Buffered UART enable interrupt on TX buffer low-water mark
 GS $D0E1.1 Buffered UART enable interrupt on RX high-water mark
 GS $D0E1.2 Buffered UART enable interrupt on RX byte
@@ -352,58 +357,57 @@ GS $D0E1.4 Buffered UART RX buffer full
 GS $D0E1.5 Buffered UART TX buffer empty
 GS $D0E1.6 Buffered UART RX buffer empty
 GS $D0E1.7 Buffered UART interrupt status
-GS $D0E1 Buffered UART Status register / interrupt select register
 GS $D0E2 Buffered UART Read register (write to ACK receipt of byte)
 GS $D0E3 Buffered UART Write register (write to send byte)
 GS $D0E4 Buffered UART bit rate divisor LSB
 GS $D0E5 Buffered UART bit rate divisor middle byte
 GS $D0E5 Buffered UART bit rate divisor MSB
-GS $D0 ETHCOMMAND:RXNORMAL Disable the effects of RXONLYONE
 C65 $D100-$D1FF VIC-III:PALRED red palette values (reversed nybl order)
 C65 $D200-$D2FF VIC-III:PALGREEN green palette values (reversed nybl order)
 C65 $D300-$D3FF VIC-III:PALBLUE blue palette values (reversed nybl order)
-C64 $D400-$D40F = right SID #1
-C64 $D420-$D43F = right SID #2
-C64 $D440-$D45F = left SID #1
-C64 $D460-$D47F = left SID #2
-C64 $D480-$D4FF = repeated images of SIDs
 GS $D4 ETHCOMMAND:DEBUGVIC Select VIC-IV debug stream via ethernet when \$D6E1.3 is set
+C64 $D400-$D40F = SID#1 (internally known as 'right SID #1' or as 'rightsid')
+C64 $D420-$D43F = SID#2 (internally known as 'right SID #2' or as 'backsid')
+C64 $D440-$D45F = SID#3 (internally known as 'left SID #1' or as 'leftsid')
+C64 $D460-$D47F = SID#4 (internally known as 'left SID #2' or as 'backsid')
+C64 $D480-$D4FF = repeated images of SIDs
 C65 $D600 UART:DATA UART data register (read or write)
+C65 $D601 C65 UART status register
 C65 $D601.0 UART:RXRDY UART RX byte ready flag (clear by reading \$D600)
 C65 $D601.1 UART:RXOVRRUN UART RX overrun flag (clear by reading \$D600)
 C65 $D601.2 UART:PTYERR UART RX parity error flag (clear by reading \$D600)
 C65 $D601.3 UART:FRMERR UART RX framing error flag (clear by reading \$D600)
-C65 $D601 C65 UART status register
+C65 $D602 C65 UART control register
 C65 $D602.0 UART:PTYEVEN UART Parity: 1=even, 0=odd
 C65 $D602.1 UART:PTYEN UART Parity enable: 1=enabled
 C65 $D602.2-3 UART:CHARSZ UART character size: 00=8, 01=7, 10=6, 11=5 bits per byte
 C65 $D602.4-5 UART:SYNCMOD UART synchronisation mode flags (00=RX \& TX both async, 01=RX sync, TX async, 1x=TX sync, RX async (unused on the MEGA65)
 C65 $D602.6 UART:RXEN UART enable receive
 C65 $D602.7 UART:TXEN UART enable transmit
-C65 $D602 C65 UART control register
 C65 $D603 UART:DIVISOR UART baud rate divisor (16 bit). Baud rate = 7.09375MHz / DIVISOR, unless MEGA65 fast UART mode is enabled, in which case baud rate = 80MHz / DIVISOR
 C65 $D604 UART:DIVISOR UART baud rate divisor (16 bit). Baud rate = 7.09375MHz / DIVISOR, unless MEGA65 fast UART mode is enabled, in which case baud rate = 80MHz / DIVISOR
 C65 $D605.4 UART:IMRXNMI UART interrupt mask: NMI on RX (not yet implemented on the MEGA65)
 C65 $D605.5 UART:IMTXNMI UART interrupt mask: NMI on TX (not yet implemented on the MEGA65)
 C65 $D605.6 UART:IMRXIRQ UART interrupt mask: IRQ on RX (not yet implemented on the MEGA65)
 C65 $D605.7 UART:IMTXIRQ UART interrupt mask: IRQ on TX (not yet implemented on the MEGA65)
+C65 $D606 C65 UART interrupt flag register              
 C65 $D606.4 UART:IFRXNMI UART interrupt flag: NMI on RX (not yet implemented on the MEGA65)
 C65 $D606.5 UART:IFTXNMI UART interrupt flag: NMI on TX (not yet implemented on the MEGA65)
 C65 $D606.6 UART:IFRXIRQ UART interrupt flag: IRQ on RX (not yet implemented on the MEGA65)
 C65 $D606.7 UART:IFTXIRQ UART interrupt flag: IRQ on TX (not yet implemented on the MEGA65)
-C65 $D606 C65 UART interrupt flag register              
+C65 $D607 C65 UART 2-bit port data register (used for C65 keyboard)
 GS $D607.0 UART:CAPLOCK C65 capslock key sense
 GS $D607.1 UART:KEYCOL8 C65 keyboard column 8 select
-C65 $D607 C65 UART 2-bit port data register (used for C65 keyboard)
-GS $D608.0-1 UART:PORTEDDR C65 keyboard extra lines Data Direction Register (DDR)
 C65 $D608 C65 UART data direction register (used for C65 keyboard)
-GS $D609.0 UARTMISC:UFAST C65 UART BAUD clock source: 1 = 7.09375MHz, 0 = 80MHz (VIC-IV pixel clock)
+GS $D608.0-1 UART:PORTEDDR C65 keyboard extra lines Data Direction Register (DDR)
 GS $D609 MEGA65 extended UART control register
+GS $D609.0 UARTMISC:UFAST C65 UART BAUD clock source: 1 = 7.09375MHz, 0 = 80MHz (VIC-IV pixel clock)
 GS $D60B.5-0 UARTMISC:PORTF PMOD port A on FPGA board (data) (Nexys4 boards only)
 GS $D60B.6 UARTMISC:OSKZON Display hardware zoom of region under first touch point always
 GS $D60B.7 UARTMISC:OSKZEN Display hardware zoom of region under first touch point for on-screen keyboard
 GS $D60C.0-5 UARTMISC:PORTFDDR PMOD port A on FPGA board (DDR)
 GS $D60C.6-7 UARTMISC:PORTFDDR On Screen Keyboard (OSK) Zoom Control Data Direction Register (DDR). Must be set to output to control these features.
+GS $D60D Bit bashing port
 GS $D60D.0 - Internal 1541 drive connect (1= use internal 1541 instead of IEC drive connector)                        
 GS $D60D.0 UARTMISC:CONN41 Internal 1541 drive connect (1=connect internal 1541 drive to IEC bus)                        
 GS $D60D.1 - Internal 1541 drive reset
@@ -414,13 +418,13 @@ GS $D60D.4 UARTMISC:SDCS SD card CS_BO
 GS $D60D.5 UARTMISC:SDBSH Enable SD card bitbash mode
 GS $D60D.6 UARTMISC:HDSDA HDMI I2C control interface SDA data line 
 GS $D60D.7 UARTMISC:HDSCL HDMI I2C control interface SCL clock 
-GS $D60D Bit bashing port
 GS $D60E UARTMISC:BASHDDR Data Direction Register (DDR) for \$D60D bit bashing port.
 GS $D60F.0 UARTMISC:KEYLEFT Directly read C65 Cursor left key
 GS $D60F.1 UARTMISC:KEYUP Directly read C65 Cursor up key
 GS $D60F.6 UARTMISC:OSKDIM Light or heavy dimming of background material behind on-screen keyboard
 GS $D60F.7 UARTMISC:ACCESSKEY Enable accessible keyboard input via joystick port 2 fire button
 GS $D610 UARTMISC:ASCIIKEY Last key press as ASCII (hardware accelerated keyboard scanner). Write to clear event ready for next.
+GS $D611 Modifier key state (hardware accelerated keyboard scanner).
 GS $D611.0 UARTMISC:MRSHFT Right shift key state (hardware accelerated keyboard scanner).
 GS $D611.0 WRITE ONLY Connect POT lines to IEC port (for r1 PCB only)
 GS $D611.1 UARTMISC:MLSHFT Left shift key state (hardware accelerated keyboard scanner).
@@ -430,7 +434,6 @@ GS $D611.3 UARTMISC:MMEGA MEGA/C= key state (hardware accelerated keyboard scann
 GS $D611.4 UARTMISC:MALT ALT key state (hardware accelerated keyboard scanner).
 GS $D611.5 UARTMISC:MSCRL NOSCRL key state (hardware accelerated keyboard scanner).
 GS $D611.6 UARTMISC:MCAPS CAPS LOCK key state (hardware accelerated keyboard scanner).
-GS $D611 Modifier key state (hardware accelerated keyboard scanner).
 GS $D612.0 UARTMISC:WGTKEY Enable widget board keyboard/joystick input
 GS $D612.1 UARTMISC:PS2KEY Enable ps2 keyboard/joystick input
 GS $D612.2 UARTMISC:PHYKEY Enable physical keyboard input
@@ -450,20 +453,20 @@ GS $D617.0-6 UARTMISC:VIRTKEY3 Set to \$7F for no key down, else specify 3nd vir
 GS $D617.7 UARTMISC:OSKTOP 1=Display on-screen keyboard at top, 0=Disply on-screen keyboard at bottom of screen.
 GS $D618 UARTMISC:KSCNRATE Physical keyboard scan rate (\$00=50MHz, \$FF=~200KHz)
 GS $D619 UARTMISC:UNUSED port o output value
+GS $D61A UARTMISC:SYSCTL System control flags (target specific)
 GS $D61A.0 SYSCTL:AUDMUTE Mute digital video audio (MEGA65 R2 only)
 GS $D61A.1 SYSCTL:DVI Control digital video as DVI (disables audio)
 GS $D61A.2 SYSCTL:AUDDBG Visualise audio samples (DEBUG)
 GS $D61A.3 SYSCTL:AUD48K Select 48KHz or 44.1KHz digital video audio sample rate
 GS $D61A.4 SYSCTL:LED Control LED next to U1 on mother board
 GS $D61A.7 SYSCTL:AUDINV Invert digital video audio sample values
-GS $D61A UARTMISC:SYSCTL System control flags (target specific)
+GS $D61B DEBUG:AMIMOUSDETECT READ 1351/amiga mouse auto detection DEBUG
 GS $D61B.0 WRITEONLY enable/disable Amiga mouse support (1351 emulation) on jostick 1
 GS $D61B.1 WRITEONLY enable/disable Amiga mouse support (1351 emulation) on jostick 2
 GS $D61B.2 WRITEONLY assume amiga mouse on jostick 1 if enabled
 GS $D61B.3 WRITEONLY assume amiga mouse on jostick 2 if enabled
 GS $D61B.6 WRITEONLY DEBUG disable ASCII key retrigger suppression
 GS $D61B.7 WRITEONLY DEBUG disable ASCII key glitch suppression
-GS $D61B DEBUG:AMIMOUSDETECT READ 1351/amiga mouse auto detection DEBUG
 GS $D61C DEBUG:1541PCLSB internal 1541 PC LSB
 GS $D61D.0-6 UARTMISC:Keyboard LED register select (R,G,B channels x 4 = 0 to 11)
 GS $D61D.7 UARTMISC:Keyboard LED control enable
@@ -473,6 +476,7 @@ GS $D620 UARTMISC:POTAX Read Port A paddle X, without having to fiddle with SID/
 GS $D621 UARTMISC:POTAY Read Port A paddle Y, without having to fiddle with SID/CIA settings.
 GS $D622 UARTMISC:POTBX Read Port B paddle X, without having to fiddle with SID/CIA settings.
 GS $D623 UARTMISC:POTBY Read Port B paddle Y, without having to fiddle with SID/CIA settings.
+GS $D624 DEBUG:POTDEBUG READ ONLY flags for paddles. See c65uart.vhdl for more information.
 GS $D624.0 Paddles connected via IEC port (rev1 PCB debug)
 GS $D624.1 pot_drain signal
 GS $D624.3-2 CIA porta bits 7-6 for POT multiplexor
@@ -480,7 +484,6 @@ GS $D624.4 fa_potx line
 GS $D624.5 fa_poty line
 GS $D624.6 fb_potx line
 GS $D624.7 fb_poty line          
-GS $D624 DEBUG:POTDEBUG READ ONLY flags for paddles. See c65uart.vhdl for more information.
 GS $D625 UARTMISC:J21L J21 pins 1 -- 6, 9 -- 10 input/output values
 GS $D626 UARTMISC:J21H J21 pins 11 -- 14 input/output values
 GS $D627 UARTMISC:J21LDDR J21 pins 1 -- 6, 9 -- 10 data direction register
@@ -504,37 +507,37 @@ GS $D638 AUXFPGA:FWGIT0 LSB of Auxilliary (MAX10) FPGA design git commit
 GS $D639 AUXFPGA:FWGIT0 2nd byte of Auxilliary (MAX10) FPGA design git commit
 GS $D63A AUXFPGA:FWGIT0 3rd byte of Auxilliary (MAX10) FPGA design git commit
 GS $D63B AUXFPGA:FWGIT0 MSB of Auxilliary (MAX10) FPGA design git commit
-GS $D640.6 - Thumbnail drawing was in progress.
-GS $D640.7 - Thumbnail is valid if 1.  Else there has not been a complete frame since elapsed without a trap to hypervisor mode, in which case the thumbnail may not reflect the current process.
-GS $D640 CPU:HTRAP00 Writing triggers hypervisor trap \$00
-GS $D640-$D641 - Read-only hardware-generated thumbnail of display (accessible only in hypervisor mode)
-GS $D640 HCPU:REGA Hypervisor A register storage
 GS $D640 - Read to obtain status of thumbnail generator.
 GS $D640 - Read to reset port address for thumbnail generator
+GS $D640 CPU:HTRAP00 Writing triggers hypervisor trap \$00
+GS $D640 HCPU:REGA Hypervisor A register storage
+GS $D640-$D641 - Read-only hardware-generated thumbnail of display (accessible only in hypervisor mode)
+GS $D640.6 - Thumbnail drawing was in progress.
+GS $D640.7 - Thumbnail is valid if 1.  Else there has not been a complete frame since elapsed without a trap to hypervisor mode, in which case the thumbnail may not reflect the current process.
+GS $D641 - Read port for thumbnail generator
 GS $D641 CPU:HTRAP01 Writing triggers hypervisor trap \$01
 GS $D641 HCPU:REGX Hypervisor X register storage
-GS $D641 - Read port for thumbnail generator
+GS $D642 - Lower 8 bits of thumbnail buffer read address (TEMPORARY DEBUG REGISTER)
 GS $D642 CPU:HTRAP02 Writing triggers hypervisor trap \$02
 GS $D642 HCPU_REGY Hypervisor Y register storage
-GS $D642 - Lower 8 bits of thumbnail buffer read address (TEMPORARY DEBUG REGISTER)
+GS $D643 - Thumbnail X position DEBUG
 GS $D643 CPU:HTRAP03 Writing triggers hypervisor trap \$03
 GS $D643 HCPU:REGZ Hypervisor Z register storage
-GS $D643 - Thumbnail X position DEBUG
+GS $D644 - Thumbnail Y position DEBUG
 GS $D644 CPU:HTRAP04 Writing triggers hypervisor trap \$04
 GS $D644 HCPU:REGB Hypervisor B register storage
-GS $D644 - Thumbnail Y position DEBUG
+GS $D645 - Thumbnail write address LSB DEBUG
 GS $D645 CPU:HTRAP05 Writing triggers hypervisor trap \$05
 GS $D645 HCPU:SPL Hypervisor SPL register storage
-GS $D645 - Thumbnail write address LSB DEBUG
+GS $D646 - Thumbnail write address MSB DEBUG
 GS $D646 CPU:HTRAP06 Writing triggers hypervisor trap \$06
 GS $D646 HCPU:SPH Hypervisor SPH register storage
-GS $D646 - Thumbnail write address MSB DEBUG
+GS $D647 - Thumbnail pixel_y LSB DEBUG
 GS $D647 CPU:HTRAP07 Writing triggers hypervisor trap \$07
 GS $D647 HCPU:PFLAGS Hypervisor P register storage
-GS $D647 - Thumbnail pixel_y LSB DEBUG
+GS $D648 - Thumbnail pixel_y MSB DEBUG
 GS $D648 CPU:HTRAP08 Writing triggers hypervisor trap \$08
 GS $D648 HCPU:PCL Hypervisor PC-low register storage
-GS $D648 - Thumbnail pixel_y MSB DEBUG
 GS $D649 CPU:HTRAP09 Writing triggers hypervisor trap \$09
 GS $D649 HCPU:PCH Hypervisor PC-high register storage
 GS $D64A CPU:HTRAP0A Writing triggers hypervisor trap \$0A
@@ -553,10 +556,10 @@ GS $D650 CPU:HTRAP10 Writing triggers hypervisor trap \$10
 GS $D650 HCPU:PORT00 Hypervisor CPU port \$00 value
 GS $D651 CPU:HTRAP11 Writing triggers hypervisor trap \$11
 GS $D651 HCPU:PORT01 Hypervisor CPU port \$01 value
+GS $D652 - Hypervisor VIC-IV IO mode
+GS $D652 CPU:HTRAP12 Writing triggers hypervisor trap \$12
 GS $D652.0-1 HCPU:VICMODE VIC-II/VIC-III/VIC-IV mode select
 GS $D652.2 HCPU:EXSID 0=Use internal SIDs, 1=Use external(1) SIDs
-GS $D652 CPU:HTRAP12 Writing triggers hypervisor trap \$12
-GS $D652 - Hypervisor VIC-IV IO mode
 GS $D653 CPU:HTRAP13 Writing triggers hypervisor trap \$13
 GS $D653 HCPU:DMASRCMB Hypervisor DMAgic source MB
 GS $D654 CPU:HTRAP14 Writing triggers hypervisor trap \$14
@@ -569,58 +572,58 @@ GS $D657 CPU:HTRAP17 Writing triggers hypervisor trap \$17
 GS $D657 HCPU:DMALADDR Hypervisor DMAGic list address bits 23-16
 GS $D658 CPU:HTRAP18 Writing triggers hypervisor trap \$18
 GS $D658 HCPU:DMALADDR Hypervisor DMAGic list address bits 27-24
+GS $D659 - Hypervisor virtualise hardware flags
+GS $D659 CPU:HTRAP19 Writing triggers hypervisor trap \$19
 GS $D659.0 HCPU:VFLOP 1=Virtualise SD/Floppy0 access (usually for access via serial debugger interface)
 GS $D659.1 HCPU:VFLOP 1=Virtualise SD/Floppy1 access (usually for access via serial debugger interface)
-GS $D659 CPU:HTRAP19 Writing triggers hypervisor trap \$19
-GS $D659 - Hypervisor virtualise hardware flags
 GS $D65A CPU:HTRAP1A Writing triggers hypervisor trap \$1A
 GS $D65B CPU:HTRAP1B Writing triggers hypervisor trap \$1B
 GS $D65C CPU:HTRAP1C Writing triggers hypervisor trap \$1C
-GS $D65D CPU:HTRAP1D Writing triggers hypervisor trap \$1D
 GS $D65D - Hypervisor current virtual page number (low byte)
-GS $D65E CPU:HTRAP1E Writing triggers hypervisor trap \$1E
+GS $D65D CPU:HTRAP1D Writing triggers hypervisor trap \$1D
 GS $D65E - Hypervisor current virtual page number (mid byte)
-GS $D65F CPU:HTRAP1F Writing triggers hypervisor trap \$1F
+GS $D65E CPU:HTRAP1E Writing triggers hypervisor trap \$1E
 GS $D65F - Hypervisor current virtual page number (high byte)
-GS $D660 CPU:HTRAP20 Writing triggers hypervisor trap \$20
+GS $D65F CPU:HTRAP1F Writing triggers hypervisor trap \$1F
 GS $D660 - Hypervisor virtual memory page 0 logical page low byte
-GS $D661 CPU:HTRAP21 Writing triggers hypervisor trap \$21
+GS $D660 CPU:HTRAP20 Writing triggers hypervisor trap \$20
 GS $D661 - Hypervisor virtual memory page 0 logical page high byte
-GS $D662 CPU:HTRAP22 Writing triggers hypervisor trap \$22
+GS $D661 CPU:HTRAP21 Writing triggers hypervisor trap \$21
 GS $D662 - Hypervisor virtual memory page 0 physical page low byte
-GS $D663 CPU:HTRAP23 Writing triggers hypervisor trap \$23
+GS $D662 CPU:HTRAP22 Writing triggers hypervisor trap \$22
 GS $D663 - Hypervisor virtual memory page 0 physical page high byte
-GS $D664 CPU:HTRAP24 Writing triggers hypervisor trap \$24
+GS $D663 CPU:HTRAP23 Writing triggers hypervisor trap \$23
 GS $D664 - Hypervisor virtual memory page 1 logical page low byte
-GS $D665 CPU:HTRAP25 Writing triggers hypervisor trap \$25
+GS $D664 CPU:HTRAP24 Writing triggers hypervisor trap \$24
 GS $D665 - Hypervisor virtual memory page 1 logical page high byte
-GS $D666 CPU:HTRAP26 Writing triggers hypervisor trap \$26
+GS $D665 CPU:HTRAP25 Writing triggers hypervisor trap \$25
 GS $D666 - Hypervisor virtual memory page 1 physical page low byte
-GS $D667 CPU:HTRAP27 Writing triggers hypervisor trap \$27
+GS $D666 CPU:HTRAP26 Writing triggers hypervisor trap \$26
 GS $D667 - Hypervisor virtual memory page 1 physical page high byte
-GS $D668 CPU:HTRAP28 Writing triggers hypervisor trap \$28
+GS $D667 CPU:HTRAP27 Writing triggers hypervisor trap \$27
 GS $D668 - Hypervisor virtual memory page 2 logical page low byte
-GS $D669 CPU:HTRAP29 Writing triggers hypervisor trap \$29
+GS $D668 CPU:HTRAP28 Writing triggers hypervisor trap \$28
 GS $D669 - Hypervisor virtual memory page 2 logical page high byte
-GS $D66A CPU:HTRAP2A Writing triggers hypervisor trap \$2A
+GS $D669 CPU:HTRAP29 Writing triggers hypervisor trap \$29
 GS $D66A - Hypervisor virtual memory page 2 physical page low byte
-GS $D66B CPU:HTRAP2B Writing triggers hypervisor trap \$2B
+GS $D66A CPU:HTRAP2A Writing triggers hypervisor trap \$2A
 GS $D66B - Hypervisor virtual memory page 2 physical page high byte
-GS $D66C CPU:HTRAP2C Writing triggers hypervisor trap \$2C
+GS $D66B CPU:HTRAP2B Writing triggers hypervisor trap \$2B
 GS $D66C - Hypervisor virtual memory page 3 logical page low byte
-GS $D66D CPU:HTRAP2D Writing triggers hypervisor trap \$2D
+GS $D66C CPU:HTRAP2C Writing triggers hypervisor trap \$2C
 GS $D66D - Hypervisor virtual memory page 3 logical page high byte
-GS $D66E CPU:HTRAP2E Writing triggers hypervisor trap \$2E
+GS $D66D CPU:HTRAP2D Writing triggers hypervisor trap \$2D
 GS $D66E - Hypervisor virtual memory page 3 physical page low byte
-GS $D66F CPU:HTRAP2F Writing triggers hypervisor trap \$2F
+GS $D66E CPU:HTRAP2E Writing triggers hypervisor trap \$2E
 GS $D66F - Hypervisor virtual memory page 3 physical page high byte
+GS $D66F CPU:HTRAP2F Writing triggers hypervisor trap \$2F
 GS $D670 CPU:HTRAP30 Writing triggers hypervisor trap \$30
 GS $D670 HCPU:GEORAMBASE Hypervisor GeoRAM base address (x MB)
 GS $D671 CPU:HTRAP31 Writing triggers hypervisor trap \$31
 GS $D671 HCPU:GEORAMMASK Hypervisor GeoRAM address mask (applied to GeoRAM block register)
-GS $D672.6 HCPU:MATRIXEN Enable composited Matrix Mode, and disable UART access to serial monitor.
-GS $D672 CPU:HTRAP32 Writing triggers hypervisor trap \$32
 GS $D672 - Protected Hardware configuration
+GS $D672 CPU:HTRAP32 Writing triggers hypervisor trap \$32
+GS $D672.6 HCPU:MATRIXEN Enable composited Matrix Mode, and disable UART access to serial monitor.
 GS $D673 CPU:HTRAP33 Writing triggers hypervisor trap \$33
 GS $D674 CPU:HTRAP34 Writing triggers hypervisor trap \$34
 GS $D675 CPU:HTRAP35 Writing triggers hypervisor trap \$35
@@ -630,10 +633,12 @@ GS $D678 CPU:HTRAP38 Writing triggers hypervisor trap \$38
 GS $D679 CPU:HTRAP39 Writing triggers hypervisor trap \$39
 GS $D67A CPU:HTRAP3A Writing triggers hypervisor trap \$3A
 GS $D67B CPU:HTRAP3B Writing triggers hypervisor trap \$3B
+GS $D67C CPU:HTRAP3C Writing triggers hypervisor trap \$3C
 GS $D67C.0-7 HCPU:UARTDATA (write) Hypervisor write serial output to UART monitor
 GS $D67C.6 - (read) Hypervisor internal immediate UART monitor busy flag (can write when 0)
 GS $D67C.7 - (read) Hypervisor serial output from UART monitor busy flag (can write when 0)
-GS $D67C CPU:HTRAP3C Writing triggers hypervisor trap \$3C
+GS $D67D CPU:HTRAP3D Writing triggers hypervisor trap \$3D
+GS $D67D HCPU:WATCHDOG Hypervisor watchdog register: writing any value clears the watch dog
 GS $D67D.0 HCPU:RSVD RESERVED
 GS $D67D.1 HCPU:JMP32EN Hypervisor enable 32-bit JMP/JSR etc
 GS $D67D.2 HCPU:ROMPROT Hypervisor write protect C65 ROM \$20000-\$3FFFF
@@ -642,15 +647,14 @@ GS $D67D.4 HCPU:CPUFAST Hypervisor force CPU to 48MHz for userland (userland can
 GS $D67D.5 HCPU:F4502 Hypervisor force CPU to 4502 personality, even in C64 IO mode.
 GS $D67D.6 HCPU:PIRQ Hypervisor flag to indicate if an IRQ is pending on exit from the hypervisor / set 1 to force IRQ/NMI deferal for 1,024 cycles on exit from hypervisor.
 GS $D67D.7 HCPU:PNMI Hypervisor flag to indicate if an NMI is pending on exit from the hypervisor.
-GS $D67D CPU:HTRAP3D Writing triggers hypervisor trap \$3D
-GS $D67D HCPU:WATCHDOG Hypervisor watchdog register: writing any value clears the watch dog
+GS $D67E CPU:HTRAP3E Writing triggers hypervisor trap \$3E
+GS $D67E HCPU:HICKED Hypervisor already-upgraded bit (writing sets permanently)
 GS $D67E.5 (read) Hypervisor read /GAME signal from cartridge.
 GS $D67E.6 (read) Hypervisor read /EXROM signal from cartridge.
 GS $D67E.7 (read) Hypervisor upgraded flag. Writing any value here sets this bit until next power on (i.e., it surives reset).
-GS $D67E CPU:HTRAP3E Writing triggers hypervisor trap \$3E
-GS $D67E HCPU:HICKED Hypervisor already-upgraded bit (writing sets permanently)
 GS $D67F CPU:HTRAP3F Writing triggers hypervisor trap \$3F
 GS $D67F HCPU:ENTEREXIT Writing trigger return from hypervisor
+GS $D680 SD:CMDANDSTAT SD controller status/command
 GS $D680.0 - SD controller BUSY flag
 GS $D680.1 - SD controller BUSY flag
 GS $D680.2 - SD controller RESET flag
@@ -659,9 +663,8 @@ GS $D680.4 - SD controller SDHC mode flag
 GS $D680.5 - SD controller SDIO FSM ERROR flag
 GS $D680.6 - SD controller SDIO error flag
 GS $D680.7 - SD controller primary / secondary SD card 
-GS $D680 SD:CMDANDSTAT SD controller status/command
-GS $D681-$D684 - SD controller SD sector address
 GS $D681 SD:SECTOR0 SD controller SD sector address (LSB)
+GS $D681-$D684 - SD controller SD sector address
 GS $D682 SD:SECTOR1 SD controller SD sector address (2nd byte)
 GS $D683 SD:SECTOR2 SD controller SD sector address (3rd byte)
 GS $D684 SD:SECTOR3 SD controller SD sector address (MSB)
@@ -672,8 +675,8 @@ GS $D687 - DEBUG SD card most recent byte read
 GS $D688 - Low-byte of F011 buffer pointer (disk side) (read only)
 GS $D689.0 - High bit of F011 buffer pointer (disk side) (read only)
 GS $D689.0 SD:BUFBIT8 (read only) reads bit 8 of the sector buffer pointer
-GS $D689.1 SD:BUFFFULL (read only) if set, indicates that the sector buffer is full and has not yet been read
 GS $D689.1 - Sector read from SD/F011/FDC, but not yet read by CPU (i.e., EQ and DRQ)
+GS $D689.1 SD:BUFFFULL (read only) if set, indicates that the sector buffer is full and has not yet been read
 GS $D689.2 - (read only, debug) sd_handshake signal.
 GS $D689.2 SD:HNDSHK Set/read SD card sd_handshake signal
 GS $D689.3 - (read only, debug) sd_data_ready signal.
@@ -684,11 +687,13 @@ GS $D689.5 - F011 swap drive 0 / 1
 GS $D689.5 SD:FDCSWAP Set to swap floppy drive 0 (the internal drive) and drive 1 (the drive on the 2nd position on the internal floppy cable).
 GS $D689.7 - Memory mapped sector buffer select: 1=SD-Card, 0=F011/FDC
 GS $D689.7 SD:BUFFSEL Set to switch sector buffer to view SD card direct access, clear for access to the F011 FDC sector buffer.
+GS $D68A - DEBUG check signals that can inhibit sector buffer mapping
 GS $D68A.0 SD:CDC00 (read only) Set if colour RAM at $DC00
 GS $D68A.1 SD:VICIII (read only) Set if VIC-IV or ethernet IO bank visible
-GS $D68A.2 SD:VDC0 (read only) Set if drive 0 is virtualized (sectors delivered via serial monitor interface)
-GS $D68A.3 SD:VDC1 (read only) Set if drive 1 is virtualized (sectors delivered via serial monitor interface)
-GS $D68A - DEBUG check signals that can inhibit sector buffer mapping
+GS $D68A.2 SD:VFDC0 (read only) Set if drive 0 is virtualised (sectors delivered via serial monitor interface)
+GS $D68A.3 SD:VFDC1 (read only) Set if drive 1 is virtualised (sectors delivered via serial monitor interface)
+GS $D68B - Diskimage control flags
+GS $D68B - F011 emulation control register
 GS $D68B.0 - F011 disk 1 disk image enable
 GS $D68B.0 SDFDC:D0IMG F011 disk 0 use disk image if set, otherwise use real floppy drive. 
 GS $D68B.1 - F011 disk 1 present
@@ -702,12 +707,10 @@ GS $D68B.6 F011:MDISK0 Enable 64MiB ``MEGA Disk'' for F011 emulated drive 0
 GS $D68B.6 SDFDC:D0MD F011 drive 0 disk image is 64MiB mega image if set (otherwise 800KiB 1581 image)
 GS $D68B.7 F011:MDISK0 Enable 64MiB ``MEGA Disk'' for F011 emulated drive 1
 GS $D68B.7 SDFDC:D1MD F011 drive 1 disk image is 64MiB mega image if set (otherwise 800KiB 1581 image)
-GS $D68B - Diskimage control flags
-GS $D68B - F011 emulation control register
-GS $D68C-$D68F - F011 disk 1 disk image address on SD card
 GS $D68C F011:DISK2ADDR0 Diskimage 2 sector number (bits 0-7)
 GS $D68C F011:DISKADDR0 Diskimage sector number (bits 0-7)
 GS $D68C SDFDC:D0STARTSEC0 F011 disk 1 disk image address on SD card (LSB)
+GS $D68C-$D68F - F011 disk 1 disk image address on SD card
 GS $D68D F011:DISK2ADDR1 Diskimage 2 sector number (bits 8-15)
 GS $D68D F011:DISKADDR1 Diskimage sector number (bits 8-15)
 GS $D68D SDFDC:D0STARTSEC1 F011 disk 1 disk image address on SD card (2nd byte)
@@ -717,8 +720,8 @@ GS $D68E SDFDC:D0STARTSEC2 F011 disk 1 disk image address on SD card (3rd byte)
 GS $D68F F011:DISK2ADDR3 Diskimage 2 sector number (bits 24-31)
 GS $D68F F011:DISKADDR3 Diskimage sector number (bits 24-31)
 GS $D68F SDFDC:D0STARTSEC3 F011 disk 1 disk image address on SD card (MSB)
-GS $D690-$D693 - F011 disk 2 disk image address on SD card
 GS $D690 SDFDC:D0STARTSEC0 F011 disk 2 disk image address on SD card (LSB)
+GS $D690-$D693 - F011 disk 2 disk image address on SD card
 GS $D691 SDFDC:D1STARTSEC1 F011 disk 2 disk image address on SD card (2nd byte)
 GS $D692 SDFDC:D2STARTSEC2 F011 disk 2 disk image address on SD card (3rd byte)
 GS $D693 SDFDC:D3STARTSEC3 F011 disk 2 disk image address on SD card (MSB)
@@ -727,16 +730,16 @@ GS $D69C DEBUG:J21INH Status of M65 R3 J21 pins
 GS $D69D DEBUG:DIPSW Status of M65 R3 DIP switches
 GS $D69E DEBUG:SWSTATUS Status of switches 0 to 7
 GS $D69F DEBUG:SWSTATUS Status of switches 8 to 15
+GS $D6A0 - 3.5" FDC control line debug access
+GS $D6A0 - DEBUG FDC read status lines
 GS $D6A0.0 FDC:DBGWGATE Control floppy drive SIDE1 line
 GS $D6A0.1 FDC:DBGWGATE Control floppy drive WGATE line
 GS $D6A0.2 FDC:DBGWDATA Control floppy drive WDATA line
-GS $D6A0 - 3.5" FDC control line debug access
 GS $D6A0.3 FDC:DBGDIR Control floppy drive STEP line
 GS $D6A0.4 FDC:DBGDIR Control floppy drive STEPDIR line
 GS $D6A0.5 FDC:DBGMOTORA Control floppy drive SELECT line
 GS $D6A0.6 FDC:DBGMOTORA Control floppy drive MOTOR line
 GS $D6A0.7 FDC:DENSITY Control floppy drive density select line
-GS $D6A0 - DEBUG FDC read status lines
 GS $D6A1.0 F011:DRV0EN Use real floppy drive instead of SD card for 1st floppy drive
 GS $D6A1.0 SDFDC:USEREAL0 Use real floppy drive for drive 0 if set (read-only, except for from hypervisor)
 GS $D6A1.1 - Match any sector on a real floppy read/write
@@ -756,23 +759,24 @@ GS $D6A9 - DEBUG FDC last gap interval (LSB)
 GS $D6AA - DEBUG FDC last gap interval (MSB)
 GS $D6AB - DEBUG FDC last 7 rdata bits (packed by mfm_gaps)
 GS $D6AC - DEBUG FDC last quantised gap
-GS $D6AD.0-3 MISCIO:WHEEL1TARGET Select audio channel volume to be set by thumb wheel #1
 GS $D6AD.0-3 - PHONE:Volume knob 1 audio target
-GS $D6AD.4-7 MISCIO:WHEEL2TARGET Select audio channel volume to be set by thumb wheel #2
+GS $D6AD.0-3 MISCIO:WHEEL1TARGET Select audio channel volume to be set by thumb wheel #1
 GS $D6AD.4-7 - PHONE:Volume knob 2 audio target
-GS $D6AE.0-3 MISCIO:WHEEL3TARGET Select audio channel volume to be set by thumb wheel #3
+GS $D6AD.4-7 MISCIO:WHEEL2TARGET Select audio channel volume to be set by thumb wheel #2
 GS $D6AE.0-3 - PHONE:Volume knob 3 audio target
-GS $D6AE.7 MISCIO:WHEELBRIGHTEN Enable control of LCD panel brightness via thumb wheel
+GS $D6AE.0-3 MISCIO:WHEEL3TARGET Select audio channel volume to be set by thumb wheel #3
 GS $D6AE.7 - PHONE:Volume knob 3 controls LCD panel brightness
-GS $D6AF.0-3 - DEBUG:FDCRTOUT Floppy index timeout
-GS $D6AF.0 SD:VFOUND Manually set f011_rsector_found signal (indented for virtual F011 mode only)
-GS $D6AF.1 SD:VFOUND Manually set f011_wsector_found signal (indented for virtual F011 mode only)
-GS $D6AF.2 SD:VFOUND Manually set f011_eq_inhibit signal (indented for virtual F011 mode only)
-GS $D6AF.3 SD:VFOUND Manually set f011_rnf signal (indented for virtual F011 mode only)
-GS $D6AF.4-7 - DEBUG:FDCIDXCNT Floppy index count
-GS $D6AF.4 SD:VFOUND Manually set f011_drq signal (indented for virtual F011 mode only)
-GS $D6AF.5 SD:VFOUND Manually set f011_lost signal (indented for virtual F011 mode only)
+GS $D6AE.7 MISCIO:WHEELBRIGHTEN Enable control of LCD panel brightness via thumb wheel
 GS $D6AF - Directly set F011 flags (intended for virtual F011 mode) WRITE ONLY
+GS $D6AF.0 SD:VRFOUND Manually set f011_rsector_found signal (indented for virtual F011 mode only)
+GS $D6AF.0-3 - DEBUG:FDCRTOUT Floppy index timeout
+GS $D6AF.1 SD:VWFOUND Manually set f011_wsector_found signal (indented for virtual F011 mode only)
+GS $D6AF.2 SD:VEQINH Manually set f011_eq_inhibit signal (indented for virtual F011 mode only)
+GS $D6AF.3 SD:VRNF Manually set f011_rnf signal (indented for virtual F011 mode only)
+GS $D6AF.4 SD:VDRQ Manually set f011_drq signal (indented for virtual F011 mode only)
+GS $D6AF.4-7 - DEBUG:FDCIDXCNT Floppy index count
+GS $D6AF.5 SD:VLOST Manually set f011_lost signal (indented for virtual F011 mode only)
+GS $D6B0 - Touch pad control / status
 GS $D6B0.0 TOUCH:EV1 Touch event 1 is valid
 GS $D6B0.1 TOUCH:EV2 Touch event 2 is valid
 GS $D6B0.2-3 TOUCH:UPDN1 Touch event 1 up/down state
@@ -781,7 +785,6 @@ GS $D6B0.6 MISCIO:TCHFLX Flip X axis of touch interface if set
 GS $D6B0.6 TOUCH:XINV Invert horizontal axis
 GS $D6B0.7 MISCIO:TCHFLX Flip Y axis of touch interface if set
 GS $D6B0.7 TOUCH:YINV Invert vertical axis
-GS $D6B0 - Touch pad control / status
 GS $D6B1 MISCIO:TCHXSCALE Set X scale value for touch interface (LSB)
 GS $D6B1 TOUCH:CALXSCALELSB Touch pad X scaling LSB
 GS $D6B2 MISCIO:TCHXSCALE Set X scale value for touch interface (MSB)
@@ -799,13 +802,13 @@ GS $D6B8 MISCIO:TCHYDELTA Set Y delta value for touch interface (MSB)
 GS $D6B8 TOUCH:CALYDELTAMSB Touch pad Y delta MSB
 GS $D6B9 TOUCH:TOUCH1XLSB Touch pad touch #1 X LSB
 GS $D6BA TOUCH:TOUCH1YLSB Touch pad touch #1 Y LSB
-GS $D6BB.0-1 TOUCH:TOUCH1XMSB Touch pad touch #1 X MSBs
-GS $D6BB.5-4 TOUCH:TOUCH1YMSB Touch pad touch #1 Y MSBs
 GS $D6BB MISCIO:TCHXDELTA Set X delta value for touch interface (MSB)
-GS $D6BC TOUCH:TOUCH2XLSB Touch pad touch #2 X LSB
-GS $D6BD TOUCH:TOUCH2YLSB Touch pad touch #2 Y LSB
-GS $D6BE.0-1 TOUCH:TOUCH2XMSB Touch pad touch #2 X MSBs
-GS $D6BE.5-4 TOUCH:TOUCH2YMSB Touch pad touch #2 Y MSBs
+GS $D6BB.0-1 TOUCH:TOUCH1XMSB Touch pad touch \#1 X MSBs
+GS $D6BB.5-4 TOUCH:TOUCH1YMSB Touch pad touch \#1 Y MSBs
+GS $D6BC TOUCH:TOUCH2XLSB Touch pad touch \#2 X LSB
+GS $D6BD TOUCH:TOUCH2YLSB Touch pad touch \#2 Y LSB
+GS $D6BE.0-1 TOUCH:TOUCH2XMSB Touch pad touch \#2 X MSBs
+GS $D6BE.5-4 TOUCH:TOUCH2YMSB Touch pad touch \#2 Y MSBs
 GS $D6BF.0-6 MISCIO:TCHBYTENUM Select byte number for touch panel communications instrumentation
 GS $D6BF.7 MISCIO:TCHI2CEN Enable/disable touch panel I2C communications
 GS $D6C0.0-3 TOUCH:GESTUREDIR Touch pad gesture directions (left,right,up,down)
@@ -815,8 +818,8 @@ GS $D6C4 FPGA:REGVAL Value of selected ICAPE2 register (least significant byte)
 GS $D6C5 FPGA:REGVAL Value of selected ICAPE2 register
 GS $D6C6 FPGA:REGVAL Value of selected ICAPE2 register
 GS $D6C7 FPGA:REGVAL Value of selected ICAPE2 register (most significant byte)
-GS $D6C8-B - Address currently loaded bitstream was fetched from flash memory.
 GS $D6C8 FPGA:BOOTADDR0 Address of bitstream in boot flash for reconfiguration (least significant byte)
+GS $D6C8-B - Address currently loaded bitstream was fetched from flash memory.
 GS $D6C9 FPGA:BOOTADDR1 Address of bitstream in boot flash for reconfiguration
 GS $D6CA FPGA:BOOTADDR2 Address of bitstream in boot flash for reconfiguration
 GS $D6CB FPGA:BOOTADDR3 Address of bitstream in boot flash for reconfiguration (most significant byte)
@@ -830,13 +833,13 @@ GS $D6CD.1 QSPI:CLOCK Alternate address for direct manipulation of QSPI CLOCK
 GS $D6CF FPGA:RECONFTRIG Write $42 to Trigger FPGA reconfiguration to switch to alternate bitstream.
 GS $D6D0 MISC:I2CBUSSELECT I2C bus select (bus 0 = temp sensor on Nexys4 boardS)
 GS $D6D0 MISCIO:I2CBUSSEL Select I2C bus number (I2C busses vary between MEGA65 and MEGAphone variants)
+GS $D6D1 - I2C control/status
 GS $D6D1.0 MISCIO:I2CRST I2C reset
 GS $D6D1.1 MISCIO:I2CL I2C command latch write strobe (write 1 to trigger command)
 GS $D6D1.2 MISCIO:I2CRW I2C Select read (1) or write (0)
 GS $D6D1.5 MISCIO:I2CSW I2C bus 1 swap SDA/SCL pins
 GS $D6D1.6 MISCIO:I2CBSY I2C busy flag
 GS $D6D1.7 MISCIO:I2CERR I2C ack error
-GS $D6D1 - I2C control/status
 GS $D6D2.7-1 MISCIO:I2CADDR I2C address
 GS $D6D3 MISCIO:I2CWDATA I2C data write register
 GS $D6D4 MISCIO:I2CRDATA I2C data read register
@@ -854,9 +857,10 @@ GS $D6E0.4 Allow remote keyboard input via magic ethernet frames
 GS $D6E0.4 ETH:KEYEN Allow remote keyboard input via magic ethernet frames
 GS $D6E0.6 ETH:RXBLKD Indicate if ethernet RX is blocked until RX buffers freed
 GS $D6E0.7 ETH:TXIDLE Ethernet transmit side is idle, i.e., a packet can be sent.
+GS $D6E1 - Ethernet interrupt and control register
 GS $D6E1.0 RESERVED
-GS $D6E1.1-2 ETH:RXBF Number of free receive buffers
 GS $D6E1.1 WRITE ONLY Access next received ethernet frame
+GS $D6E1.1-2 ETH:RXBF Number of free receive buffers
 GS $D6E1.2 WRITE ONLY Enable real-time CPU/BUS monitoring via ethernet
 GS $D6E1.3 Enable real-time video streaming via ethernet (or fast IO bus if CPU/bus monitoring enabled)
 GS $D6E1.3 ETH:STRM Enable streaming of CPU instruction stream or VIC-IV display on ethernet
@@ -864,7 +868,6 @@ GS $D6E1.4 ETH:TXQ Ethernet TX IRQ status
 GS $D6E1.5 ETH:RXQ Ethernet RX IRQ status
 GS $D6E1.6 ETH:TXQEN Enable ethernet TX IRQ
 GS $D6E1.7 ETH:RXQEN Enable ethernet RX IRQ
-GS $D6E1 - Ethernet interrupt and control register
 GS $D6E2 ETH:TXSZLSB TX Packet size (low byte)
 GS $D6E2 Set low-order size of frame to TX
 GS $D6E3 ETH:TXSZMSB TX Packet size (high byte)
@@ -873,9 +876,9 @@ GS $D6E4 ETH:COMMAND Ethernet command register (write only)
 GS $D6E5.0 ETH:NOPROM Ethernet disable promiscuous mode
 GS $D6E5.1 Disable CRC check for received packets
 GS $D6E5.1 ETH:NOCRC Disable CRC check for received packets
-GS $D6E5.2-3 Ethernet TX clock phase adjust
 GS $D6E5.2-3 ETH:RXPH Ethernet RX clock phase adjust
 GS $D6E5.2-3 ETH:TXPH Ethernet TX clock phase adjust
+GS $D6E5.2-3 Ethernet TX clock phase adjust
 GS $D6E5.4 ETH:BCST Accept broadcast frames
 GS $D6E5.5 ETH:MCST Accept multicast frames
 GS $D6E5.6-7 Ethernet RX clock phase adjust
@@ -891,8 +894,8 @@ GS $D6ED ETH:MACADDR5 Ethernet MAC address
 GS $D6EE ETH:MACADDR6 Ethernet MAC address
 GS $D6EF ETH:DBGRXWCOUNT DEBUG show number of writes to eth RX buffer
 GS $D6EF ETH:DBGTXSTAT DEBUG show current ethernet TX state
-GS $D6F0 MISCIO:LCDBRIGHT LCD panel brightness control
 GS $D6F0 MISC:LCDBRIGHTNESS LCD panel brightness control
+GS $D6F0 MISCIO:LCDBRIGHT LCD panel brightness control
 GS $D6F2 MISC:FPGABUTTONS Read FPGA five-way buttons
 GS $D6F3 MISC:ACCELBITBASH Accelerometer bit-bash interface
 GS $D6F3 MISCIO:ACCELBASH Accelerometer bit-bashing port (debug only)
@@ -917,7 +920,6 @@ C65 $D701 DMA:ADDRMSB DMA list address high byte (address bits 8 -- 15).
 C65 $D702 DMA:ADDRBANK DMA list address bank (address bits 16 -- 22). Writing clears \$D704.
 GS $D703.0 DMA:EN018B DMA enable F018B mode (adds sub-command byte)
 GS $D704 DMA:ADDRMB DMA list address mega-byte
-GS $D705 DMA:ETRIG Set low-order byte of DMA list address, and trigger Enhanced DMA job (uses DMA option list)
 GS $D705 - Enhanced DMAgic job option $00 = End of options
 GS $D705 - Enhanced DMAgic job option $06 = Use $86 $xx transparency value (don't write source bytes to destination, if byte value matches $xx)
 GS $D705 - Enhanced DMAgic job option $07 = Disable $86 $xx transparency value.
@@ -930,7 +932,10 @@ GS $D705 - Enhanced DMAgic job option $83 $xx = Set source skip rate (whole byte
 GS $D705 - Enhanced DMAgic job option $84 $xx = Set destination skip rate (/256ths of bytes)
 GS $D705 - Enhanced DMAgic job option $85 $xx = Set destination skip rate (whole bytes)
 GS $D705 - Enhanced DMAgic job option $86 $xx = Don't write to destination if byte value = $xx, and option $06 enabled
+GS $D705 DMA:ETRIG Set low-order byte of DMA list address, and trigger Enhanced DMA job (uses DMA option list)
 GS $D70E DMA:ADDRLSB DMA list address low byte (address bits 0 -- 7) WITHOUT STARTING A DMA JOB (used by Hypervisor for unfreezing DMA-using tasks)
+GS $D70F.6 MATH:MULBUSY Set if hardware multiplier is busy
+GS $D70F.7 MATH:DIVBUSY Set if hardware divider is busy
 GS $D710.0 - CPU:BADLEN Enable badline emulation
 GS $D710.1 - CPU:SLIEN Enable 6502-style slow (7 cycle) interrupts
 GS $D710.2 - MISC:VDCSEN Enable VDC inteface simulation
@@ -961,12 +966,12 @@ GS $D726 DMA:CH0FREQ Audio DMA channel 0 frequency MSB
 GS $D727 DMA:CH0TADDR Audio DMA channel 0 top address LSB
 GS $D728 DMA:CH0TADDR Audio DMA channel 0 top address middle byte
 GS $D729 DMA:CH0VOLUME Audio DMA channel 0 playback volume
-GS $D72A DMA:CH0FREQ Audio DMA channel 0 current address LSB
-GS $D72B DMA:CH0FREQ Audio DMA channel 0 current address middle byte
-GS $D72C DMA:CH0FREQ Audio DMA channel 0 current address MSB
-GS $D72D DMA:CH0FREQ Audio DMA channel 0 timing counter LSB
-GS $D72E DMA:CH0FREQ Audio DMA channel 0 timing counter middle byte
-GS $D72F DMA:CH0FREQ Audio DMA channel 0 timing counter address MSB
+GS $D72A DMA:CH0CURADDR Audio DMA channel 0 current address LSB
+GS $D72B DMA:CH0CURADDR Audio DMA channel 0 current address middle byte
+GS $D72C DMA:CH0CURADDR Audio DMA channel 0 current address MSB
+GS $D72D DMA:CH0TMRADDR Audio DMA channel 0 timing counter LSB
+GS $D72E DMA:CH0TMRADDR Audio DMA channel 0 timing counter middle byte
+GS $D72F DMA:CH0TMRADDR Audio DMA channel 0 timing counter address MSB
 GS $D730.0-1 DMA:CH1SBITS Audio DMA channel 1 sample bits (11=16, 10=8, 01=upper nybl, 00=lower nybl)
 GS $D730.3 DMA:CH1STP Audio DMA channel 1 stop flag
 GS $D730.4 DMA:CH1SINE Audio DMA channel 1 play 32-sample sine wave instead of DMA data
@@ -982,12 +987,12 @@ GS $D736 DMA:CH1FREQ Audio DMA channel 1 frequency MSB
 GS $D737 DMA:CH1TADDR Audio DMA channel 1 top address LSB
 GS $D738 DMA:CH1TADDR Audio DMA channel 1 top address middle byte
 GS $D739 DMA:CH1VOLUME Audio DMA channel 1 playback volume
-GS $D73A DMA:CH1FREQ Audio DMA channel 1 current address LSB
-GS $D73B DMA:CH1FREQ Audio DMA channel 1 current address middle byte
-GS $D73C DMA:CH1FREQ Audio DMA channel 1 current address MSB
-GS $D73D DMA:CH1FREQ Audio DMA channel 1 timing counter LSB
-GS $D73E DMA:CH1FREQ Audio DMA channel 1 timing counter middle byte
-GS $D73F DMA:CH1FREQ Audio DMA channel 1 timing counter address MSB
+GS $D73A DMA:CH1CURADDR Audio DMA channel 1 current address LSB
+GS $D73B DMA:CH1CURADDR Audio DMA channel 1 current address middle byte
+GS $D73C DMA:CH1CURADDR Audio DMA channel 1 current address MSB
+GS $D73D DMA:CH1TMRADDR Audio DMA channel 1 timing counter LSB
+GS $D73E DMA:CH1TMRADDR Audio DMA channel 1 timing counter middle byte
+GS $D73F DMA:CH1TMRADDR Audio DMA channel 1 timing counter address MSB
 GS $D740.0-1 DMA:CH1SBITS Audio DMA channel 1 sample bits (11=16, 10=8, 01=upper nybl, 00=lower nybl)
 GS $D740.3 DMA:CH2STP Audio DMA channel 2 stop flag
 GS $D740.4 DMA:CH2SINE Audio DMA channel 2 play 32-sample sine wave instead of DMA data
@@ -1003,12 +1008,12 @@ GS $D746 DMA:CH2FREQ Audio DMA channel 2 frequency MSB
 GS $D747 DMA:CH2TADDR Audio DMA channel 2 top address LSB
 GS $D748 DMA:CH2TADDR Audio DMA channel 2 top address middle byte
 GS $D749 DMA:CH2VOLUME Audio DMA channel 2 playback volume
-GS $D74A DMA:CH2FREQ Audio DMA channel 2 current address LSB
-GS $D74B DMA:CH2FREQ Audio DMA channel 2 current address middle byte
-GS $D74C DMA:CH2FREQ Audio DMA channel 2 current address MSB
-GS $D74D DMA:CH2FREQ Audio DMA channel 2 timing counter LSB
-GS $D74E DMA:CH2FREQ Audio DMA channel 2 timing counter middle byte
-GS $D74F DMA:CH2FREQ Audio DMA channel 2 timing counter address MSB
+GS $D74A DMA:CH2CURADDR Audio DMA channel 2 current address LSB
+GS $D74B DMA:CH2CURADDR Audio DMA channel 2 current address middle byte
+GS $D74C DMA:CH2CURADDR Audio DMA channel 2 current address MSB
+GS $D74D DMA:CH2TMRADDR Audio DMA channel 2 timing counter LSB
+GS $D74E DMA:CH2TMRADDR Audio DMA channel 2 timing counter middle byte
+GS $D74F DMA:CH2TMRADDR Audio DMA channel 2 timing counter address MSB
 GS $D750.0-1 DMA:CH3SBITS Audio DMA channel 3 sample bits (11=16, 10=8, 01=upper nybl, 00=lower nybl)
 GS $D750.3 DMA:CH3STP Audio DMA channel 3 stop flag
 GS $D750.4 DMA:CH3SINE Audio DMA channel 3 play 32-sample sine wave instead of DMA data
@@ -1024,27 +1029,27 @@ GS $D756 DMA:CH3FREQ Audio DMA channel 3 frequency MSB
 GS $D757 DMA:CH3TADDR Audio DMA channel 3 top address LSB
 GS $D758 DMA:CH3TADDR Audio DMA channel 3 top address middle byte
 GS $D759 DMA:CH3VOLUME Audio DMA channel 3 playback volume
-GS $D75A DMA:CH3FREQ Audio DMA channel 3 current address LSB
-GS $D75B DMA:CH3FREQ Audio DMA channel 3 current address middle byte
-GS $D75C DMA:CH3FREQ Audio DMA channel 3 current address MSB
-GS $D75D DMA:CH3FREQ Audio DMA channel 3 timing counter LSB
-GS $D75E DMA:CH3FREQ Audio DMA channel 3 timing counter middle byte
-GS $D75F DMA:CH3FREQ Audio DMA channel 3 timing counter address MSB
-GS $D768 MATH:MULTOUT 64-bit output of MULTINA $\div$ MULTINB
-GS $D769 MATH:MULTOUT 64-bit output of MULTINA $\div$ MULTINB
-GS $D76A MATH:MULTOUT 64-bit output of MULTINA $\div$ MULTINB
-GS $D76B MATH:MULTOUT 64-bit output of MULTINA $\div$ MULTINB
-GS $D76C MATH:MULTOUT 64-bit output of MULTINA $\div$ MULTINB
-GS $D76D MATH:MULTOUT 64-bit output of MULTINA $\div$ MULTINB
-GS $D76E MATH:MULTOUT 64-bit output of MULTINA $\div$ MULTINB
-GS $D76F MATH:MULTOUT 64-bit output of MULTINA $\div$ MULTINB
-GS $D770-3 32-bit multiplier input A
+GS $D75A DMA:CH3CURADDR Audio DMA channel 3 current address LSB
+GS $D75B DMA:CH3CURADDR Audio DMA channel 3 current address middle byte
+GS $D75C DMA:CH3CURADDR Audio DMA channel 3 current address MSB
+GS $D75D DMA:CH3TMRADDR Audio DMA channel 3 timing counter LSB
+GS $D75E DMA:CH3TMRADDR Audio DMA channel 3 timing counter middle byte
+GS $D75F DMA:CH3TMRADDR Audio DMA channel 3 timing counter address MSB
+GS $D768 MATH:DIVOUT 64-bit output of MULTINA $\div$ MULTINB
+GS $D769 MATH:DIVOUT 64-bit output of MULTINA $\div$ MULTINB
+GS $D76A MATH:DIVOUT 64-bit output of MULTINA $\div$ MULTINB
+GS $D76B MATH:DIVOUT 64-bit output of MULTINA $\div$ MULTINB
+GS $D76C MATH:DIVOUT 64-bit output of MULTINA $\div$ MULTINB
+GS $D76D MATH:DIVOUT 64-bit output of MULTINA $\div$ MULTINB
+GS $D76E MATH:DIVOUT 64-bit output of MULTINA $\div$ MULTINB
+GS $D76F MATH:DIVOUT 64-bit output of MULTINA $\div$ MULTINB
 GS $D770 MATH:MULTINA Multiplier input A / Divider numerator (32 bit)
+GS $D770-3 32-bit multiplier input A
 GS $D771 MATH:MULTINA Multiplier input A / Divider numerator (32 bit)
 GS $D772 MATH:MULTINA Multiplier input A / Divider numerator (32 bit)
 GS $D773 MATH:MULTINA Multiplier input A / Divider numerator (32 bit)
-GS $D774-7 32-bit multiplier input B
 GS $D774 MATH:MULTINB Multiplier input B / Divider denominator (32 bit)
+GS $D774-7 32-bit multiplier input B
 GS $D775 MATH:MULTINB Multiplier input B / Divider denominator (32 bit)
 GS $D776 MATH:MULTINB Multiplier input B / Divider denominator (32 bit)
 GS $D777 MATH:MULTINB Multiplier input B / Divider denominator (32 bit)
@@ -1056,8 +1061,8 @@ GS $D77C MATH:MULTOUT 64-bit output of MULTINA $\times$ MULTINB
 GS $D77D MATH:MULTOUT 64-bit output of MULTINA $\times$ MULTINB
 GS $D77E MATH:MULTOUT 64-bit output of MULTINA $\times$ MULTINB
 GS $D77F MATH:MULTOUT 64-bit output of MULTINA $\times$ MULTINB
-GS $D780-$D7BF - 16 x 32 bit Math Unit values
 GS $D780 MATH:MATHIN0 Math unit 32-bit input 0
+GS $D780-$D7BF - 16 x 32 bit Math Unit values
 GS $D781 MATH:MATHIN0 Math unit 32-bit input 0
 GS $D782 MATH:MATHIN0 Math unit 32-bit input 0
 GS $D783 MATH:MATHIN0 Math unit 32-bit input 0
@@ -1121,9 +1126,9 @@ GS $D7BC MATH:MATHIN15 Math unit 32-bit input 15
 GS $D7BD MATH:MATHIN15 Math unit 32-bit input 15
 GS $D7BE MATH:MATHIN15 Math unit 32-bit input 15
 GS $D7BF MATH:MATHIN15 Math unit 32-bit input 15
+GS $D7C0-$D7CF - 16 Math function unit input A (3-0) and input B (7-4) selects
 GS $D7C0.0-3 MATH:UNIT0INA Select which of the 16 32-bit math registers is input A for Math Function Unit 0.
 GS $D7C0.4-7 MATH:UNIT0INB Select which of the 16 32-bit math registers is input B for Math Function Unit 0.
-GS $D7C0-$D7CF - 16 Math function unit input A (3-0) and input B (7-4) selects
 GS $D7C1.0-3 MATH:UNIT1INA Select which of the 16 32-bit math registers is input A for Math Function Unit 1.
 GS $D7C1.4-7 MATH:UNIT1INB Select which of the 16 32-bit math registers is input B for Math Function Unit 1.
 GS $D7C2.0-3 MATH:UNIT2INA Select which of the 16 32-bit math registers is input A for Math Function Unit 2.
@@ -1234,11 +1239,11 @@ GS $D7DF.4 - MATH:UFLOWOUT If set, the low-half of the output of Math Function U
 GS $D7DF.5 - MATH:UFHIOUT If set, the high-half of the output of Math Function Unit F is written to math register UNIT15OUT.
 GS $D7DF.6 - MATH:UFADD If set, Math Function Unit F acts as a 32-bit adder instead of 32-bit divider.
 GS $D7DF.7 - MATH:UFLATCH If set, Math Function Unit F's output is latched.
-GS $D7E0 MATH:LATCHINT Latch interval for latched outputs (in CPU cycles)
 GS $D7E0 - Math unit latch interval (only update output of math function units every this many cycles, if they have the latch output flag set)
+GS $D7E0 MATH:LATCHINT Latch interval for latched outputs (in CPU cycles)
+GS $D7E1 - Math unit general settings (writing also clears math cycle counter)
 GS $D7E1.0 MATH:WREN Enable setting of math registers (must normally be set)
 GS $D7E1.1 MATH:CALCEN Enable committing of output values from math units back to math registers (clearing effectively pauses iterative formulae)
-GS $D7E1 - Math unit general settings (writing also clears math cycle counter)
 GS $D7E2 MATH:RESERVED Reserved
 GS $D7E3 MATH:RESERVED Reserved
 GS $D7E4 MATH:ITERCNT Iteration Counter (32 bit)
@@ -1249,6 +1254,7 @@ GS $D7E8 MATH:ITERCMP Math iteration counter comparator (32 bit)
 GS $D7E9 MATH:ITERCMP Math iteration counter comparator (32 bit)
 GS $D7EA MATH:ITERCMP Math iteration counter comparator (32 bit)
 GS $D7EB MATH:ITERCMP Math iteration counter comparator (32 bit)
+GS $D7F1.0 CPU:IECBUSACT IEC bus is active
 GS $D7F2 CPU:PHIPERFRAME Count the number of PHI cycles per video frame (LSB)              
 GS $D7F5 CPU:PHIPERFRAME Count the number of PHI cycles per video frame (MSB)
 GS $D7F6 CPU:CYCPERFRAME Count the number of usable (proceed=1) CPU cycles per video frame (LSB)              
@@ -1261,6 +1267,7 @@ GS $D7FD.6 CPU:NOGAME Override for /GAME : Must be 0 to enable /GAME signal
 GS $D7FD.7 CPU:NOEXROM Override for /EXROM : Must be 0 to enable /EXROM signal
 GS $D7FE.0 CPU:PREFETCH Enable expansion RAM pre-fetch logic
 GS $D7FE.1 CPU:OCEANA Enable Ocean Type A cartridge emulation
+GS $DC ETHCOMMAND:DEBUGCPU Select CPU debug stream via ethernet when \$D6E1.3 is set
 C64 $DC00 CIA1:PORTA Port A 
 C64 $DC01 CIA1:PORTB Port B
 C64 $DC02 CIA1:DDRA Port A DDR
@@ -1275,13 +1282,13 @@ C64 $DC0A.0-5 CIA1:TODSEC TOD minutes
 C64 $DC0B.0-4 CIA1:TODHOUR TOD hours
 C64 $DC0B.7 CIA1:TODAMPM TOD PM flag
 C64 $DC0C CIA1:SDR shift register data register(writing starts sending)
+C64 $DC0D CIA1 ISR : Reading clears events
 C64 $DC0D.0 CIA1:TA Timer A underflow
 C64 $DC0D.1 CIA1:TB Timer B underflow
 C64 $DC0D.2 CIA1:ALRM TOD alarm
 C64 $DC0D.3 CIA1:SP shift register full/empty
 C64 $DC0D.4 CIA1:FLG FLAG edge detected
 C64 $DC0D.7 CIA1:IR Interrupt flag
-C64 $DC0D CIA1 ISR : Reading clears events
 C64 $DC0E.0 CIA1:STRTA Timer A start
 C64 $DC0E.1 CIA1:PBONA Timer A PB6 out
 C64 $DC0E.2 CIA1:OMODA Timer A toggle or pulse
@@ -1318,7 +1325,6 @@ GS $DC1D CIA1:ALRMSEC TOD Alarm seconds value
 GS $DC1E CIA1:ALRMMIN TOD Alarm minutes value
 GS $DC1F.0-6 CIA1:ALRMHOUR TOD Alarm hours value
 GS $DC1F.7 CIA1:ALRMAMPM TOD Alarm AM/PM flag
-GS $DC ETHCOMMAND:DEBUGCPU Select CPU debug stream via ethernet when \$D6E1.3 is set
 C64 $DD00 CIA2:PORTA Port A 
 C64 $DD01 CIA2:PORTB Port B
 C64 $DD02 CIA2:DDRA Port A DDR
@@ -1333,12 +1339,12 @@ C64 $DD0A.0-5 CIA2:TODSEC TOD minutes
 C64 $DD0B.0-4 CIA2:TODHOUR TOD hours
 C64 $DD0B.7 CIA2:TODAMPM TOD PM flag
 C64 $DD0C CIA2:SDR shift register data register(writing starts sending)
+C64 $DD0D CIA2 ISR : Reading clears events
 C64 $DD0D.0 CIA2:TA Timer A underflow
 C64 $DD0D.1 CIA2:TB Timer B underflow
 C64 $DD0D.2 CIA2:ALRM TOD alarm
 C64 $DD0D.3 CIA2:SP shift register full/empty
 C64 $DD0D.4 CIA2:FLG FLAG edge detected
-C64 $DD0D CIA2 ISR : Reading clears events
 C64 $DD0E.0 CIA2:STRTA Timer A start
 C64 $DD0E.1 CIA2:PBONA Timer A PB6 out
 C64 $DD0E.2 CIA2:OMODA Timer A toggle or pulse
@@ -1371,12 +1377,12 @@ GS $DD1A CIA2:TODMIN TOD Alarm minutes value
 GS $DD1B.0-6 CIA2:TODHOUR TOD hours value
 GS $DD1B.7 CIA2:TODAMPM TOD AM/PM flag
 GS $DD1C CIA2:ALRMJIF TOD Alarm 10ths of seconds value
+GS $DD1C.7 CIA2:DD00DELAY Enable delaying writes to $DD00 by 3 cycles to match real 6502 timing
 GS $DD1D CIA2:ALRMSEC TOD Alarm seconds value
 GS $DD1E CIA2:ALRMMIN TOD Alarm minutes value
 GS $DD1F.0-6 CIA2:ALRMHOUR TOD Alarm hours value
 GS $DD1F.7 CIA2:ALRMAMPM TOD Alarm AM/PM flag
 GS $DE ETHCOMMAND:RXONLYONE Receive exactly one ethernet frame only, and keep all signals states (for debugging ethernet sub-system)
-GS ETH:$D6E0 Ethernet control
 GS $F1 ETHCOMMAND:FRAME1K Select ~1KiB frames for video/cpu debug stream frames (for receivers that do not support MTUs of greater than 2KiB)
 GS $F2 ETHCOMMAND:FRAME2K Select ~2KiB frames for video/cpu debug stream frames, for optimal performance.
 GS $FF7E000-$FF7EFFF SUMMARY:CHARWRITE VIC-IV CHARROM write area
@@ -1395,8 +1401,8 @@ GS $FFD70F4 - ADC3 smoothed value (LSB)
 GS $FFD70F5 - ADC3 smoothed value (MSB)
 GS $FFD7100-07 UUID:UUID64 64-bit UUID. Can be used to seed ethernet MAC address
 GS $FFD7100-FF EDID:EDID E-EDID block (MEGA65 R3 and newer, only)
-GS $FFD7110-3F RTC:RTC Real-time Clock
 GS $FFD7110 RTC:RTCSEC Real-time Clock seconds value (binary coded decimal)
+GS $FFD7110-3F RTC:RTC Real-time Clock
 GS $FFD7111 RTC:RTCMIN Real-time Clock minutes value (binary coded decimal)
 GS $FFD7112 RTC:RTCHOUR Real-time Clock hours value (binary coded decimal)
 GS $FFD7113 RTC:RTCDAY Real-time Clock day of month value (binary coded decimal)
@@ -1448,3 +1454,4 @@ GS $FFF8108 Hypervisor entry point on RESTORE long-press (trap $42)
 GS $FFF810C Hypervisor entry point on C=-TAB / ALT-TAB (trap $43)
 GS $FFF8110 Hypervisor entry point on FDC read (when virtualised) (trap $44)
 GS $FFF8114 Hypervisor entry point on FDC write (when virtualised) (trap $45)
+GS ETH:$D6E0 Ethernet control

--- a/src/vhdl/iomapper.vhdl
+++ b/src/vhdl/iomapper.vhdl
@@ -1839,10 +1839,10 @@ begin
       end if;
 
       -- Now map the SIDs
-      -- @IO:C64 $D400-$D40F = right SID #1
-      -- @IO:C64 $D420-$D43F = right SID #2
-      -- @IO:C64 $D440-$D45F = left SID #1
-      -- @IO:C64 $D460-$D47F = left SID #2
+      -- @IO:C64 $D400-$D40F = SID#1 (internally known as 'right SID #1' or as 'rightsid')
+      -- @IO:C64 $D420-$D43F = SID#2 (internally known as 'right SID #2' or as 'backsid')
+      -- @IO:C64 $D440-$D45F = SID#3 (internally known as 'left SID #1' or as 'leftsid')
+      -- @IO:C64 $D460-$D47F = SID#4 (internally known as 'left SID #2' or as 'backsid')
       -- @IO:C64 $D480-$D4FF = repeated images of SIDs
       -- Presumably repeated through to $D5FF.  But we will repeat to $D4FF only
       -- so that we can use $D500-$D5FF for other stuff.


### PR DESCRIPTION
#372: Improved the comment inside "iomap.txt" to share the new 'external'-facing names for the SIDs (and also hint at what the internal names are)

- I've re-run "make iomap.txt", it generated more changes than I expected, but not necessarily bad changes, the ordering seems 'nicer'.

NOTE: I'll need to commit a newer submodule reference to 'mega65-freezemenu' as part of this PR (once my PR-review there is completed)