### PR TITLE
Fix #389 - Add GHDL into Makefile & Documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,9 +147,16 @@ src/tools/acme/src/acme:
 	( cd src/tools/acme/src && make -j 8 )
 
 
+ghdl/ghdl_mcode: ghdl/build/bin/ghdl
+	$(warning =============================================================)
+	$(warning ~~~~~~~~~~~~~~~~> Making: $@)
+	# GHDL submodule is compiled by ghdl/build/bin/ghdl
+
+
 ghdl/build/bin/ghdl:
 	$(warning =============================================================)
 	$(warning ~~~~~~~~~~~~~~~~> Making: $@)
+	# APT Package gnat is a prerequisite for this to succeed, as described in the documentation
 	git submodule init
 	git submodule update
 	( cd ghdl && ./configure --prefix=./build && make -j 8 && make install )

--- a/docs/build.md
+++ b/docs/build.md
@@ -118,6 +118,7 @@ The following is assumed:
 1. you have ```python``` installed (I have ver 2.7.10) (for some scripts)
 1. you have ```libpng12-dev``` installed (for the image manipulation) (alternatively use libpng-dev to install)
 1. you have ```cbmconvert``` installed (I have ver 2.1.2) (to make a D81 image) (refer to ./using.md)
+1. you have ```gnat``` installed (for compiling the GHDL submodule)
 1. you have a recent version of Xilinx Vivado WebPACK edition installed, with a valid licence (recommended that you install to directory /opt/Xilinx to prevent issue with makefile)
 
 Overview of the compile process:


### PR DESCRIPTION
This is a solution to #389 is to add a new target, in this case being used as an "alias". This target then calls the already existing ``ghdl/build/bin/ghdl`` target to facilitate the build.

It is unclear if other targets or build tools use ``ghdl/ghdl_mcode`` in any capacity, so I opted to add functionality to this to stay on the safe side.

Regarding the ``apt`` comment, I believe it is in the best interest of the makefile to not include the ``apt`` call, as this would require elevated privileges to run. No other dependencies via package managers are automatically installed, and this is no exception.