### PR TITLE
potential fix for loading of deleted '?ICKUP.M65' file

### DIFF
--- a/src/hyppo/dos.asm
+++ b/src/hyppo/dos.asm
@@ -3027,7 +3027,7 @@ dff4:   lda dos_dirent_longfilename,x
         cmp dos_requested_filename,x
         bne dff3
         dex
-        bne dff4
+        bpl dff4
 
         ;; File names match, so return success
 


### PR DESCRIPTION
Well, from tonight's debugging, I saw there was already logic in-place to ignore files with the 'E5' deleted marker.

But either way, it's still a good fix for a missing comparison on the first byte of the string.