### PR TITLE
Overflow flag for Q-opcodes

### DIFF
--- a/src/vhdl/gs4510.vhdl
+++ b/src/vhdl/gs4510.vhdl
@@ -7531,7 +7531,7 @@ begin
                   flag_c <= not reg_val33(32);
                   flag_v <= (reg_q33(31) xor reg_val33(31)) and (reg_q33(31) xor reg_val32(31)); -- reg_val33 <= reg_q33 - reg_val32
                 when I_CMP => flag_c <= not reg_val33(32); -- no overflow for cmpq!
-                  when others =>
+                when others =>
                   null;
               end case;
               -- Do we need to write back to registers or not?


### PR DESCRIPTION
Added Overflow flag to ADCQ, SBCQ and CMPQ.

Bitstream synthesis was successful, but lacking hardware I was not able to do a test of the bitstream.

Pre-build bitstream and unit test #459 : https://t.ktk.de/index.php/s/BaDozdqyAzspKrb