### PR TITLE
Implementation of Q pseudo register addressing mode instructions

### DIFF
--- a/src/hyppo/debugtests.asm
+++ b/src/hyppo/debugtests.asm
@@ -308,4 +308,22 @@
 ;; }
 ;; // f011test()
 
-
+!macro QOPTEST {
+-
+        lda #$00
+        ldx #$56
+        ldy #$34
+        ldz #$12
+        neg
+        neg
+        dec
+        php
+        sta $2200
+        stx $2201
+        sty $2202
+        stz $2203
+        pla
+        sta $2204
+        bra -
+}
+;; +QOPTEST

--- a/src/hyppo/debugtests.asm
+++ b/src/hyppo/debugtests.asm
@@ -308,22 +308,22 @@
 ;; }
 ;; // f011test()
 
-!macro QOPTEST {
--
-        lda #$00
-        ldx #$56
-        ldy #$34
-        ldz #$12
-        neg
-        neg
-        dec
-        php
-        sta $2200
-        stx $2201
-        sty $2202
-        stz $2203
-        pla
-        sta $2204
-        bra -
-}
+;; !macro QOPTEST {
+;; -
+;;         lda #$00
+;;         ldx #$56
+;;         ldy #$34
+;;         ldz #$12
+;;         neg
+;;         neg
+;;         dec
+;;         php
+;;         sta $2200
+;;         stx $2201
+;;         sty $2202
+;;         stz $2203
+;;         pla
+;;         sta $2204
+;;         bra -
+;; }
 ;; +QOPTEST

--- a/src/hyppo/main.asm
+++ b/src/hyppo/main.asm
@@ -551,21 +551,6 @@ reset_entry:
 	map
 	eom
 
-        lda #$00
-        ldx #$56
-        ldy #$34
-        ldz #$12
-        neg
-        neg
-        dec
-        php
-        sta $2200
-        stx $2201
-        sty $2202
-        stz $2203
-        pla
-        sta $2204
-
 !src "debugtests.asm"
 
         jsr reset_machine_state

--- a/src/hyppo/main.asm
+++ b/src/hyppo/main.asm
@@ -551,6 +551,21 @@ reset_entry:
 	map
 	eom
 
+        lda #$00
+        ldx #$56
+        ldy #$34
+        ldz #$12
+        neg
+        neg
+        dec
+        php
+        sta $2200
+        stx $2201
+        sty $2202
+        stz $2203
+        pla
+        sta $2204
+
 !src "debugtests.asm"
 
         jsr reset_machine_state


### PR DESCRIPTION
Implements the missing Q opcodes: INQ Q, DEQ Q, LSRQ Q, ASRQ Q, ASLQ Q, ROLQ Q, RORQ Q as mentioned in #469 

Tuned so that synthesis for nexys4ddr-widget and mega65r3 do not show any extra timing violations.

Adds extra temp33 variable to do it in one stage. Doing a union (temp_addr and temp17 are aliased into temp33) results in lots of timing violations, so this was no solution.