### PR TITLE
Support building on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -913,6 +913,9 @@ $(VHDLSRCDIR)/uart_monitor.vhdl.tmp $(VHDLSRCDIR)/uart_monitor.vhdl:	$(VERILOGSR
 
 
 $(SDCARD_DIR)/BANNER.M65:	$(TOOLDIR)/pngprepare/pngprepare assets/mega65_320x64.png
+ifndef CONVERT
+	$(error The convert command was not found. ImageMagick might not be installed.)
+endif
 	mkdir -p $(SDCARD_DIR)
 	$(CONVERT) -colors 128 -depth 8 +dither assets/mega65_320x64.png $(BINDIR)/mega65_320x64_128colour.png
 	$(TOOLDIR)/pngprepare/pngprepare logo $(BINDIR)/mega65_320x64_128colour.png $(SDCARD_DIR)/BANNER.M65

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,8 @@ VERILOGSRCDIR=	$(SRCDIR)/verilog
 
 SDCARD_DIR=	sdcard-files
 
+CONVERT=	$(firstword $(wildcard /usr/bin/convert /usr/local/bin/convert))
+
 # if you want your PRG to appear on "MEGA65.D81", then put your PRG in "./d81-files"
 # ie: COMMANDO.PRG
 #
@@ -912,7 +914,7 @@ $(VHDLSRCDIR)/uart_monitor.vhdl.tmp $(VHDLSRCDIR)/uart_monitor.vhdl:	$(VERILOGSR
 
 $(SDCARD_DIR)/BANNER.M65:	$(TOOLDIR)/pngprepare/pngprepare assets/mega65_320x64.png
 	mkdir -p $(SDCARD_DIR)
-	/usr/$(BINDIR)/convert -colors 128 -depth 8 +dither assets/mega65_320x64.png $(BINDIR)/mega65_320x64_128colour.png
+	$(CONVERT) -colors 128 -depth 8 +dither assets/mega65_320x64.png $(BINDIR)/mega65_320x64_128colour.png
 	$(TOOLDIR)/pngprepare/pngprepare logo $(BINDIR)/mega65_320x64_128colour.png $(SDCARD_DIR)/BANNER.M65
 
 # disk menu program for loading from SD card to $C000 on boot by hyppo

--- a/Makefile
+++ b/Makefile
@@ -728,7 +728,7 @@ $(UTILDIR)/megaflash-a200t.prg:       $(UTILDIR)/megaflash.c $(CC65_DEPEND)
 		$(SRCDIR)/mega65-libc/cc65/src/memory.c $(SRCDIR)/mega65-libc/cc65/src/hal.c
 	# Make sure that result is not too big.  Top must be below < $$8000 after loading, so that
 	# it doesn't overlap with hypervisor
-	stat -c"%s" $(UTILDIR)/megaflash-a200t.prg
+	-stat -c"%s" $(UTILDIR)/megaflash-a200t.prg
 	test -n "$$(find $(UTILDIR)/megaflash-a200t.prg -size -29000c)"
 
 $(UTILDIR)/hyperramtest.prg:       $(UTILDIR)/hyperramtest.c $(wildcard $(SRCDIR)/mega65-libc/cc65/src/*.c) $(wildcard $(SRCDIR)/mega65-libc/cc65/src/*.s) $(wildcard $(SRCDIR)/mega65-libc/cc65/include/*.h) $(CC65_DEPEND)


### PR DESCRIPTION
These are some patches to the top-level Makefile to allow it be used with macOS.
Although I've only used it to build `src/vhdl/shadowram-a200t.vhdl`.