### PR TITLE
Clear the correct file descriptor entry in dos_get_free_descriptor

### DIFF
--- a/src/hyppo/dos.asm
+++ b/src/hyppo/dos.asm
@@ -2072,24 +2072,34 @@ dgfd1:  txa
 
 dgfd_found_free:
 
+        stx dos_current_file_descriptor
+        sty dos_current_file_descriptor_offset
+
+        ;; Push the address dos_file_descriptors + dos_current_file_descriptor_offset
+        ;;
+        clc
+        lda #<dos_file_descriptors
+        adc dos_current_file_descriptor_offset
+        tay
+        lda #>dos_file_descriptors
+        adc #$00
+        pha
+        phy
+
         ;; Clear descriptor entry
         ;;
         ldy #$0f
         lda #$00
 
-dgfd2:  sta dos_file_descriptors,y
+dgfd2:  sta ($01,sp),y
         dey
         bne dgfd2
 
+        ;; Pop the address
+        pla
+        pla
+
         ;; Return file descriptor in X
-        ;;
-        stx dos_current_file_descriptor
-        txa
-        asl
-        asl
-        asl
-        asl
-        sta dos_current_file_descriptor_offset
         sec
         rts
 


### PR DESCRIPTION
`dos_get_free_descriptor` was always clearing the first file description entry.
As an added bonus, doesn't calculate `dos_current_file_descriptor_offset` twice.