### PR TITLE
Close the correct file descriptor entry in trap_dos_closefile

### DIFF
--- a/src/hyppo/dos.asm
+++ b/src/hyppo/dos.asm
@@ -852,6 +852,7 @@ trap_dos_closefile:
 
         jsr dos_get_file_descriptor_offset
         bcc tdcf1
+        sta dos_current_file_descriptor_offset
         jsr dos_closefile
         bcc tdcf1
 


### PR DESCRIPTION
`dos_closefile` expects `dos_current_file_descriptor_offset` to be already set. `trap_dos_closefile` was calculating it but leaving it in A and X.