### PR TITLE
Clear the file descriptors in dos_clear_filedescriptors

### DIFF
--- a/src/hyppo/dos.asm
+++ b/src/hyppo/dos.asm
@@ -1031,17 +1031,10 @@ dos_clear_filedescriptors:
         sta currenttask_filedescriptor3
 
 	;; XXX - Doesn't flush any files open for write
-	ldx #0
-@closenextfiledescriptor:
-	phx
-	jsr dos_get_file_descriptor_offset
-	plx
-	tay
-        lda #$ff ;; not allocated flag for file descriptor
-        sta dos_file_descriptors + dos_filedescriptor_offset_diskid,y
-	inx
-	cpx #4
-	bne @closenextfiledescriptor
+        sta dos_file_descriptors
+        sta dos_file_descriptors+$10
+        sta dos_file_descriptors+$20
+        sta dos_file_descriptors+$30
 	
         sec
         rts


### PR DESCRIPTION
This wasn't working because `dos_get_file_descriptor_offset` calculates the offset for the file descriptor number in `dos_current_file_descriptor` and not the X register.

`dos_clearall` also closes all the file descriptors — as well as clearing `dos_disk_table`. I replace the code in `dos_clear_filedescriptors` with the code from `dos_clearall`.