### PR TITLE
Conditionally exclude debug-related code when building HICKUP.M65.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,13 @@
 COPT=	-Wall -g -std=gnu99
 CC=	gcc
 
+
+# Set DEBUG_HYPPO to 1 to include code that is useful debugging Hyppo itself
+ifndef DEBUG_HYPPO
+	DEBUG_HYPPO= 0
+endif
+
+
 ifdef USE_LOCAL_OPHIS
 	# use locally installed binary (requires 'ophis' to be in the $PATH)
 	OPHIS=	ophis
@@ -829,8 +836,8 @@ $(BINDIR)/border.prg: 	$(SRCDIR)/border.a65 $(OPHIS_DEPEND)
 	$(OPHIS) $(OPHISOPT) $< -l $(BINDIR)/border.list -m $*.map -o $(BINDIR)/border.prg
 
 # ============================ done moved, print-warn, clean-target
-$(BINDIR)/HICKUP.M65: $(ACME_DEPEND) $(SRCDIR)/hyppo/main.asm $(SRCDIR)/version.asm
-	$(ACME) --cpu m65 --setpc 0x8000 -l src/hyppo/HICKUP.sym -r src/hyppo/HICKUP.rep -I $(SRCDIR)/hyppo $(SRCDIR)/hyppo/main.asm
+$(BINDIR)/HICKUP.M65: $(ACME_DEPEND) $(wildcard $(SRCDIR)/hyppo/*.asm) $(SRCDIR)/version.asm
+	$(ACME) --cpu m65 --setpc 0x8000 -l src/hyppo/HICKUP.sym -r src/hyppo/HICKUP.rep -I $(SRCDIR)/hyppo -DDEBUG_HYPPO=$(DEBUG_HYPPO) $(SRCDIR)/hyppo/main.asm
 
 $(SRCDIR)/monitor/monitor_dis.a65: $(SRCDIR)/monitor/gen_dis
 	$(SRCDIR)/monitor/gen_dis >$(SRCDIR)/monitor/monitor_dis.a65

--- a/src/hyppo/dos.asm
+++ b/src/hyppo/dos.asm
@@ -273,6 +273,7 @@ illegalvalue:
 
         ;; BG: the below section seems never called from anywhere: suggest removal
 
+!if DEBUG_HYPPO {
 ;;         tya
 ;;         tax
 ;;         jsr checkpoint_bytetohex
@@ -282,6 +283,7 @@ illegalvalue:
 ;;         jsr checkpoint
 ;;         .byte 0,"Filename contains $00 @ position $"
 ;; iv1:        .byte "%%",0
+}
 
         lda #dos_errorcode_illegal_value
         sta dos_error_code
@@ -892,6 +894,7 @@ trap_dos_geterrorcode:
         lda dos_error_code
         sta hypervisor_a
 
+!if DEBUG_HYPPO {
         tax                                ;; convert .X to char-representation for display
         jsr checkpoint_bytetohex        ;; returns: .X and .Y (Y is MSB, X is LSB, print YX)
         sty tdgec1+0
@@ -902,6 +905,7 @@ trap_dos_geterrorcode:
         !text "dos_geterrorcode <=$"
 tdgec1: !text "%%>"
         !8 0
+}
 
         jmp return_from_trap_with_success
 
@@ -1286,7 +1290,9 @@ dcpe1:  lda (<dos_scratch_vector),y
         jsr dos_disk_openpartition
         bcc partitionerror
 
+!if DEBUG_HYPPO {
         jsr dump_disk_table
+}
 
         ;; Check if partition is bootable (or the only partition)
         ;; If so, make the partition the default disk
@@ -1304,6 +1310,7 @@ makethispartitionthedefault:
         lda dos_disk_count
         sta dos_default_disk
 
+!if DEBUG_HYPPO {
         ;; print out this message to Checkpoint
         ;;
 
@@ -1319,6 +1326,7 @@ mtptd:  !text "xx"
         !8 0
 
 ;; jsr dump_disk_table
+}
 
         ;; return OK
         ;;
@@ -1331,6 +1339,7 @@ dontmakethispartitionthedefault:
 
         ldx dos_disk_count
 
+!if DEBUG_HYPPO {
         ;; print out this message to Checkpoint
         ;;
 
@@ -1345,6 +1354,7 @@ mtptd2: !text "x NOT set to the default_disk"
         !8 0
 
 ;; jsr dump_disk_table
+}
 
         ;; return OK
         ;;
@@ -1374,6 +1384,7 @@ partitionerror:
 
         ;; return ERROR
 
+!if DEBUG_HYPPO {
         ldx dos_error_code                ;; convert .X to char-representation for display
         jsr checkpoint_bytetohex        ;; returns: .X and .Y (Y is MSB, X is LSB, print YX)
         sty perr
@@ -1384,6 +1395,7 @@ partitionerror:
         !text "partitionerror="
 perr:   !text "xx"
         !8 0
+}
 
         clc
         rts
@@ -1424,7 +1436,9 @@ ddop1:  lda dos_disk_table,y
         cpx #$04
         bne ddop1
 
+!if DEBUG_HYPPO {
 jsr dumpsectoraddress        ;; debugging
+}
 
         jsr sd_readsector
         bcc partitionerror
@@ -1918,6 +1932,7 @@ dos_set_current_disk:
         asl
         sta dos_disk_table_offset
 
+!if DEBUG_HYPPO {
         ldx dos_disk_current_disk        ;; convert .X to char-representation for display
         jsr checkpoint_bytetohex        ;; returns: .X and .Y (Y is MSB, X is LSB, print YX)
         sty dscd+0
@@ -1930,6 +1945,7 @@ dos_set_current_disk:
         !text "dos_set_current_disk="
 dscd:   !text "xx"
         !8 0
+}
 
         sec
         rts
@@ -2368,6 +2384,7 @@ dos_readdir:
 
         jsr dos_file_read_current_sector
 
+!if DEBUG_HYPPO {
 ;; debug info, unsure what byte is being displayed...
 ;;
         +Checkpoint "-"
@@ -2400,6 +2417,7 @@ drdcp0: !text "xxyy]"
         jsr dumpfddata                ;; debug
 
 ;; end of debug
+}
 
         ldx dos_current_file_descriptor_offset
         lda dos_file_descriptors + dos_filedescriptor_offset_mode,x
@@ -2459,6 +2477,7 @@ drce_next_piece:
 
         ;; (dos_scratch_vector) now has the address of the directory entry
 
+!if DEBUG_HYPPO {
         phx        ;; as the code below clobbers X
 
         ;; print out filename and attrib
@@ -2505,6 +2524,7 @@ eight3char1:
         !8 0
 
         plx        ;; as the code above clobbers X
+}
 
 ;;         ========================
 
@@ -2939,14 +2959,17 @@ l_dos_readdir:
 +
         +Checkpoint "drce_not_eof CHECK<3/3>"
 
+!if DEBUG_HYPPO {
         ldx dos_dirent_longfilename_length
         jsr lfndebug
+}
 
         sec
         rts
 
 ;;         ========================
 
+!if DEBUG_HYPPO {
 lfndebug:
         ;; requires .X to be set
         ;;
@@ -2975,11 +2998,13 @@ fnmsg1: !text ".............................." ;; BG: why only 30 chars?
         !8 0
 
         rts
+}
 
 ;;         ========================
 
 drd_deleted_or_invalid_entry:
 
+!if DEBUG_HYPPO {
         tax
                                         ;; convert .X to char-representation for display
         jsr checkpoint_bytetohex        ;; returns: .X and .Y (Y is MSB, X is LSB, print YX)
@@ -2990,6 +3015,7 @@ drd_deleted_or_invalid_entry:
         !8 0
 ddie:   !text "xx drd_deleted_or_invalid_entry"
         !8 0
+}
 	
         jsr dos_readdir_advance_to_next_entry
         bcc +
@@ -3540,6 +3566,7 @@ dfanc4: plp
 
 ;;         ========================
 
+!if DEBUG_HYPPO {
 dos_print_current_cluster:
 
         ;; prints a message to the screen
@@ -3560,6 +3587,7 @@ dos_print_current_cluster:
         +Checkpoint "dos_print_current_cluster"
 
         rts
+}
 
 ;;         ========================
 

--- a/src/hyppo/main.asm
+++ b/src/hyppo/main.asm
@@ -551,7 +551,9 @@ reset_entry:
 	map
 	eom
 
-!src "debugtests.asm"
+!if DEBUG_HYPPO {
+        !src "debugtests.asm"
+}
 
         jsr reset_machine_state
 
@@ -704,8 +706,10 @@ fpga_has_been_reconfigured:
 
 normalboot:
 
+!if DEBUG_HYPPO {
         jsr dump_disk_count        ;; debugging to Checkpoint
         jsr dumpcurrentfd        ;; debugging to Checkpoint
+}
 
         ;; Try to read the MBR from the SD card to ensure SD card is happy
         ;;
@@ -825,9 +829,11 @@ gotmbr:
         ldz dos_default_disk
         jsr printhex
 
+!if DEBUG_HYPPO {
         jsr dump_disk_count     ;; debugging to Checkpoint
         jsr dumpcurrentfd       ;; debugging to Checkpoint
 ;;             jsr print_disk_table        ; debugging to Screen
+}
 
 ;;         ========================
 
@@ -1054,9 +1060,11 @@ posthickup:
 
         ;; print debug message
         ;;
+!if DEBUG_HYPPO {
         +Checkpoint "  Here we are POST-HICKUP"
 
         jsr dumpcurrentfd        ;; debugging to Checkpoint
+}
 
         ;; for now indicate that there is no disk in drive
         ;; (unless we notice that floppy access has been virtualised)
@@ -1191,7 +1199,9 @@ attempt_load1541rom:
 
 loadrom:
 
+!if DEBUG_HYPPO {
         jsr dumpcurrentfd        ;; debugging to Checkpoint
+}
 
         ;; ROMs are not loaded, so try to load them, or prompt
         ;; for user to insert SD card
@@ -1212,6 +1222,7 @@ loadrom:
 ;;         ========================
 
 loadedcharromok:
+!if DEBUG_HYPPO {
         ;; print debug message
         ;;
         +Checkpoint "  OK-loading CHARROM"
@@ -1223,19 +1234,26 @@ loadedcharromok:
         sta file_pagesread
         lda dos_file_descriptors + dos_filedescriptor_offset_fileoffset+1,x
         sta file_pagesread+1
+}
 
         ldx #<msg_charromloaded
         ldy #>msg_charromloaded
         jsr printmessage
+
+
+!if DEBUG_HYPPO {
         ldy #$00
         ldz file_pagesread+1
         jsr printhex
         ldz file_pagesread
         jsr printhex
+}
 
 loadc65rom:
 
+!if DEBUG_HYPPO {
         jsr dumpcurrentfd        ;; debugging to Checkpoint
+}
 
         ;; print debug message
         ;;
@@ -1326,6 +1344,7 @@ charromdmalist:
 
 loadedmegaromok:
 
+!if DEBUG_HYPPO {
         ;; prepare debug message
         ;;
         ldx dos_current_file_descriptor_offset
@@ -1333,15 +1352,19 @@ loadedmegaromok:
         sta file_pagesread
         lda dos_file_descriptors + dos_filedescriptor_offset_fileoffset+1,x
         sta file_pagesread+1
+}
 
         ldx #<msg_megaromloaded
         ldy #>msg_megaromloaded
         jsr printmessage
+
+!if DEBUG_HYPPO {
         ldy #$00
         ldz file_pagesread+1
         jsr printhex
         ldz file_pagesread
         jsr printhex
+}
 
         ;; ROM file loaded, transfer control
         ;;
@@ -1363,8 +1386,9 @@ loadedmegaromok:
         jsr printmessage
 
 loaded1541rom:
+!if DEBUG_HYPPO {
         jsr dumpcurrentfd        ;; debugging to Checkpoint
-
+}
         ;; check for keyboard input to jump to utility menu
         jsr utility_menu_check
         jsr scankeyboard
@@ -1381,10 +1405,12 @@ romfiletoolong:
         ldx #<msg_romfilelongerror
         ldy #>msg_romfilelongerror
         jsr printmessage
+!if DEBUG_HYPPO {
         ldz file_pagesread+1
         jsr printhex
         ldz file_pagesread
         jsr printhex
+}
         jsr sdwaitawhile
         jmp reset_entry
 
@@ -1392,10 +1418,12 @@ romfiletooshort:
         ldx #<msg_romfileshorterror
         ldy #>msg_romfileshorterror
         jsr printmessage
+!if DEBUG_HYPPO {
         ldz file_pagesread+1
         jsr printhex
         ldz file_pagesread
         jsr printhex
+}
         jsr sdwaitawhile
         jmp reset_entry
 
@@ -1889,9 +1917,11 @@ pm4:                ;; write 16-bit character code
 endofmessage:
         inc screenrow
 
+!if DEBUG_HYPPO {
 	;; XXX DEBUG
 	;; Require key press after each line displayed.
 ;;	jsr debug_wait_on_key
+}
 
 	plz
 	rts
@@ -2342,6 +2372,8 @@ hscr1:
 
 ;;         ========================
 
+!if DEBUG_HYPPO {
+
 checkpoint:
 
         ;; Routine to record the progress of code through the hypervisor for
@@ -2532,6 +2564,9 @@ checkpoint_nybltohex:
 
 cpnth1: adc #$06
         rts
+
+} ;; !if DEBUG_HYPPO
+
 
 ;;         ========================
 ;;       Scan the 32KB colour RAM looking for pre-loaded utilities.
@@ -3003,6 +3038,8 @@ serialwrite:
 
 ;;         ========================
 
+!if DEBUG_HYPPO {
+
 ;; checkpoint message
 
 msg_checkpoint:         !text "$"
@@ -3014,6 +3051,8 @@ msg_checkpoint_z:       !text "%%, P:"
 msg_checkpoint_p:       !text "%% :"
 msg_checkpointmsg:      !text "                                                             " ;; END_OF_STRING
                         !8 13,10  ;; CR/LF
+
+}
 
 ;;         ========================
 
@@ -3175,7 +3214,9 @@ txt_NTSC:               !text "NTSC"
 
 ;;         ========================
 
-!src "debug.asm"
+!if DEBUG_HYPPO {
+        !src "debug.asm"
+}
 
 ;;         ========================
 
@@ -3446,6 +3487,7 @@ zptempv32b:
 dos_file_loadaddress:
         !16 0,0
 
+!if DEBUG_HYPPO {
         ;; Used for checkpoint debug system of hypervisor
         ;;
 checkpoint_a:
@@ -3462,6 +3504,7 @@ checkpoint_pcl:
         !8 0
 checkpoint_pch:
         !8 0
+}
 
         ;; SD card timeout handling
         ;;

--- a/src/hyppo/sdfat.asm
+++ b/src/hyppo/sdfat.asm
@@ -29,17 +29,11 @@ readmbr:
         ;; begin by resetting SD card
         ;;
 
-        jsr checkpoint
-        !8 0
-        !text "Resetting SDCARD"
-        !8 0
+        +Checkpoint "Resetting SDCARD"
 
         jsr sd_resetsequence
         bcs l7
-        jsr checkpoint
-        !8 0
-        !text "FAILED resetting SDCARD"
-        !8 0
+        +Checkpoint "FAILED resetting SDCARD"
 
         rts
 
@@ -255,11 +249,12 @@ sd_readsector:
         ;; Assumes fixed sector number (or byte address in case of SD cards)
         ;; is loaded into $D681 - $D684
 
+!if DEBUG_HYPPO {
         ;; print out debug info
         ;;
 ;;         jsr printsectoraddress        ; to screen
-
         jsr dumpsectoraddress        ;; checkpoint message
+}
 
         ;; check if sd card is busy
         ;;
@@ -284,10 +279,7 @@ redoread:
         ldy #>msg_sdredoread
         jsr printmessage
 
-        jsr checkpoint                        ;; we never want to do a redo-read
-        !8 0
-        !text "ERROR redoread:"
-        !8 0
+        +Checkpoint "ERROR redoread:"
 
         ldx #$f0
         ldy #$00
@@ -323,10 +315,7 @@ rereadsector:
         ;; reset sd card and try again
         ;;
 
-        jsr checkpoint                        ;; we should never get here
-        !8 0
-        !text "ERROR rereadsector:"
-        !8 0
+        +Checkpoint "ERROR rereadsector:"
 
         jsr sd_resetsequence
         jmp rs4
@@ -335,10 +324,7 @@ rsbusyfail:     ;; fail
         ;;
         lda #dos_errorcode_read_timeout
         sta dos_error_code
-        jsr checkpoint                        ;; we should not ever get here
-        !8 0
-        !text "ERROR rsbusyfail:"
-        !8 0
+        +Checkpoint "ERROR rsbusyfail:"
 
         clc
         rts


### PR DESCRIPTION
Free up 2KB¹ in HICKUP.M65 by excluding debug-related code from non-debug builds.

Introduces a DEBUG_HYPPO define to Makefile and puts debug-related code inside conditional directive that only assembles the debug-related code if DEBUG_HYPPO is not zero. DEBUG_HYPPO default to zero. Debug build of HICKUP.M65 can be made with `DEBUG_HYPPO=1 make`.

This doesn't touch code that is already commented out, including the body of the Checkpoint macro. DEBUG_HYPPO=1 does not activate the Checkpoint macro.

Replaces direct calls to checkpoint in sdfat.asm with the Checkpoint macro.

---

¹ Looking at `src/hyppo/HICKUP.rep` after building with DEBUG_HYPPO=1, the code occupies $8000 - $bb01. When DEBUG_HYPPO=0, it occupies $8000 - $b2c3.