### PR TITLE
Sprite collision fix

### DIFF
--- a/src/tools/makerom/makerom
+++ b/src/tools/makerom/makerom
@@ -1,68 +1,66 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 
 from os.path import realpath, dirname, join
 from sys import argv, path
 
 if len(argv) < 4:
-  print "Usage:", argv[0], "<template-file> <binary-file> <output-file> <component-name>"
-  exit()
+  print("Usage: %s <template-file> <binary-file> <output-file> <component-name>" % (sys.argv[0],))
+  exit(1)
 
-print "argv=", argv
-print "argv[0]= the name of this python script"
-print "argv[1]= the template vhdl file"
-print "argv[2]= the binary data to embedd into the ROM"
-print "argv[3]= the name of the output vhdl-file (without extension)"
-print "argv[4]= the component name within the output vhdl-file"
+print(f"argv={argv}")
+print("argv[0]= the name of this python script")
+print("argv[1]= the template vhdl file")
+print("argv[2]= the binary data to embedd into the ROM")
+print("argv[3]= the name of the output vhdl-file (without extension)")
+print("argv[4]= the component name within the output vhdl-file")
 
 # Read a binary file and use it to make an initialised RAM
 
-file3=open(argv[3]+".vhdl","w")
-print "Opened ", file3.name, "for ", file3.mode
+file3 = open(argv[3]+".vhdl", "w")
+print(f'Opened {file3.name} for {file3.mode}')
 
 # Read in the ROM file
-romdata=""
+romdata = ""
 
 file2 = open(argv[2], "rb")
-print "Opened ", file2.name, "for ", file2.mode
+print(f"Opened {file2.name} for {file2.mode}")
 
 bytes_read = file2.read()
 
-first=True
-c=0;
-count=0
+first = True
+c = 0
+count = 0
 for b in bytes_read:
     if first:
-        first=False
+        first = False
     else:
-        romdata=romdata+","
-    if c==8:
-        c=0;
+        romdata += ","
+    if c == 8:
+        c = 0
     #if c==0:
     #        romdata=romdata+"\n  -- "+hex(count+0xe000)+"\n  "
-    romdata=romdata+"x\""+b.encode('hex').upper()+"\""
-    count=count+1
-    c=c+1;    
+    romdata += 'x"%02X"' % (b,)
+    count += 1
+    c += 1
 
-print "read ", count, " bytes from", file2.name
+print(f"read {count} bytes from {file2.name}")
 
 # Read ROM template file
-file1=open(argv[1])
-print "Opened ", file1.name, "for ", file1.mode
+file1 = open(argv[1])
+print(f"Opened {file1.name} for {file1.mode}")
 
-lines=file1.readlines()
+lines = file1.readlines()
 for line in lines:
-    if line.find("THEROM")>-1:
-        line=line.replace("THEROM",argv[4])
-    if line.find("ROMDATA")>-1:
-        line=line.replace("ROMDATA",romdata)
+    line = line.replace("THEROM", argv[4])
+    line = line.replace("ROMDATA", romdata)
     file3.write(line)
 
-print "Wrote ", file3.name
+print(f"Wrote {file3.name}")
 
 # Close the opened files
-file3.close
-print "Closed ", file3.name
-file2.close
-print "Closed ", file2.name
-file1.close
-print "Closed ", file1.name
+file3.close()
+print(f"Closed {file3.name}")
+file2.close()
+print(f"Closed {file2.name}")
+file1.close()
+print(f"Closed {file1.name}")

--- a/src/tools/makerom/makerom
+++ b/src/tools/makerom/makerom
@@ -1,13 +1,13 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from os.path import realpath, dirname, join
-from sys import argv, path
+from sys import argv
 
 if len(argv) < 4:
-  print("Usage: %s <template-file> <binary-file> <output-file> <component-name>" % (sys.argv[0],))
+  print("Usage: %s <template-file> <binary-file> <output-file> <component-name>" % (argv[0],))
   exit(1)
 
-print(f"argv={argv}")
+print("argv={}".format(argv))
 print("argv[0]= the name of this python script")
 print("argv[1]= the template vhdl file")
 print("argv[2]= the binary data to embedd into the ROM")
@@ -17,13 +17,13 @@ print("argv[4]= the component name within the output vhdl-file")
 # Read a binary file and use it to make an initialised RAM
 
 file3 = open(argv[3]+".vhdl", "w")
-print(f'Opened {file3.name} for {file3.mode}')
+print('Opened {} for {}'.format(file3.name, file3.mode))
 
 # Read in the ROM file
 romdata = ""
 
 file2 = open(argv[2], "rb")
-print(f"Opened {file2.name} for {file2.mode}")
+print("Opened {} for {}".format(file2.name, file2.mode))
 
 bytes_read = file2.read()
 
@@ -43,11 +43,11 @@ for b in bytes_read:
     count += 1
     c += 1
 
-print(f"read {count} bytes from {file2.name}")
+print("read {} bytes from {}".format(count, file2.name))
 
 # Read ROM template file
-file1 = open(argv[1])
-print(f"Opened {file1.name} for {file1.mode}")
+file1 = open(argv[1], 'r')
+print("Opened {} for {}".format(file1.name, file1.mode))
 
 lines = file1.readlines()
 for line in lines:
@@ -55,12 +55,12 @@ for line in lines:
     line = line.replace("ROMDATA", romdata)
     file3.write(line)
 
-print(f"Wrote {file3.name}")
+print("Wrote {}".format(file3.name))
 
 # Close the opened files
 file3.close()
-print(f"Closed {file3.name}")
+print("Closed {}".format(file3.name))
 file2.close()
-print(f"Closed {file2.name}")
+print("Closed {}".format(file2.name))
 file1.close()
-print(f"Closed {file1.name}")
+print("Closed {}".format(file1.name))

--- a/src/vhdl/viciv.vhdl
+++ b/src/vhdl/viciv.vhdl
@@ -3011,6 +3011,19 @@ begin
 
       sprite_fetch_drive <= '0';
 
+      -- Acknowledge IRQs after reading $D019
+      irq_raster <= irq_raster and (not ack_raster);
+      irq_rasterx <= irq_rasterx and (not ack_rasterx);
+      irq_lightpen <= irq_lightpen and (not ack_lightpen);
+      irq_collisionspritebitmap <= irq_collisionspritebitmap and (not ack_collisionspritebitmap);
+      irq_collisionspritesprite <= irq_collisionspritesprite and (not ack_collisionspritesprite);
+      -- Set IRQ line status to CPU
+      irq_drive <= not ((irq_raster and mask_raster)
+                        or (irq_rasterx and mask_rasterx and irq_extras_enable)
+                        or (irq_lightpen and mask_lightpen)
+                        or (irq_collisionspritebitmap and mask_collisionspritebitmap)
+                        or (irq_collisionspritesprite and mask_collisionspritesprite));
+
       -- Add new sprite collision bits to the bitmap
       case vicii_sprite_sprite_collision_map is
         when "00000000" => null;
@@ -3062,19 +3075,6 @@ begin
       if clear_collisionspritebitmap='1' then
         vicii_sprite_bitmap_collisions <= vicii_sprite_bitmap_collision_map;
       end if;
-
-      -- Acknowledge IRQs after reading $D019
-      irq_raster <= irq_raster and (not ack_raster);
-      irq_rasterx <= irq_rasterx and (not ack_rasterx);
-      irq_lightpen <= irq_lightpen and (not ack_lightpen);
-      irq_collisionspritebitmap <= irq_collisionspritebitmap and (not ack_collisionspritebitmap);
-      irq_collisionspritesprite <= irq_collisionspritesprite and (not ack_collisionspritesprite);
-      -- Set IRQ line status to CPU
-      irq_drive <= not ((irq_raster and mask_raster)
-                        or (irq_rasterx and mask_rasterx and irq_extras_enable)
-                        or (irq_lightpen and mask_lightpen)
-                        or (irq_collisionspritebitmap and mask_collisionspritebitmap)
-                        or (irq_collisionspritesprite and mask_collisionspritesprite));
 
       -- Detect lightpen event (must appear above irq_lightpen assignment above)
       if touch_active='1' and xcounter_drive(11 downto 0) = touch_x and displayy = touch_y then


### PR DESCRIPTION
Sprite collision detection needed to be done after IRQ ack part.
Combined setting and resetting of new collision bitsets to get rid of single sprite-sprite collisions.
As only dual sprite collision are now added to the sets, IRQ trigger could be simplified.

Fixed #484 

Build and tested on nexys4ddr-widget, no extra timing violations.