### PR TITLE
Have trap_dos_geterrorcode return error code of prior trap_dos_setname.

### DIFF
--- a/src/hyppo/dos.asm
+++ b/src/hyppo/dos.asm
@@ -263,7 +263,8 @@ trap_dos_setname:
 ;;         ========================
 
 tdsnfailure:
-        lda dos_error_code
+        ;; save the error code so a later trap_dos_geterrorcode will return it
+        sta dos_error_code
         jmp return_from_trap_with_failure
 
 ;;         ========================


### PR DESCRIPTION
Neither hypervisor_setup_copy_region nor dos_setname set dos_error_code. They both just return the error code in A.