### PR TITLE
Return the file descriptor in A from trap_dos_findfirst

### DIFF
--- a/src/hyppo/dos.asm
+++ b/src/hyppo/dos.asm
@@ -876,6 +876,8 @@ trap_dos_findfile:
 trap_dos_findfirst:
 
         jsr dos_findfirst
+        lda dos_current_file_descriptor
+        sta hypervisor_a
         jmp return_from_trap_with_carry_flag
 
 ;;         ========================


### PR DESCRIPTION
`trap_dos_findfile` opens a file descriptor for the directory, but it is the programmer's responsibility to close it. In order to close it, they need to know what it is.

The A register was chosen to align with `trap_dos_opendir`.