### PR TITLE
Signal if trap_dos_cdrootdir fails

### DIFF
--- a/src/hyppo/dos.asm
+++ b/src/hyppo/dos.asm
@@ -800,7 +800,7 @@ trap_dos_readfile:
 
 trap_dos_cdrootdir:
 	jsr dos_cdroot
-	jmp return_from_trap_with_success
+	jmp return_from_trap_with_carry_flag
 	
 trap_dos_chdir:
 


### PR DESCRIPTION
When the SD card partition in X does not exist, clear the C flag.