### PR TITLE
Return the file descriptor in A from trap_dos_openfile

### DIFF
--- a/src/hyppo/dos.asm
+++ b/src/hyppo/dos.asm
@@ -732,9 +732,7 @@ trap_dos_opendir:
 tdod1:
         ;; Directory opened ok.
         ;;
-        lda dos_current_file_descriptor
-        sta hypervisor_a
-        jmp return_from_trap_with_success
+        jmp return_from_trap_with_success_and_file_descriptor_in_a
 
 ;;         ========================
 
@@ -840,9 +838,7 @@ trap_dos_openfile:
 
         +Checkpoint "trap_dos_openfile <success>"
 
-        lda dos_current_file_descriptor
-        sta hypervisor_a
-        jmp return_from_trap_with_success
+        jmp return_from_trap_with_success_and_file_descriptor_in_a
 
 tdof1:
         +Checkpoint "trap_dos_openfile <failure>"
@@ -884,9 +880,9 @@ trap_dos_findfile:
 trap_dos_findfirst:
 
         jsr dos_findfirst
-        lda dos_current_file_descriptor
-        sta hypervisor_a
-        jmp return_from_trap_with_carry_flag
+        bcc +
+        jmp return_from_trap_with_success_and_file_descriptor_in_a
++	jmp return_from_trap_with_failure
 
 ;;         ========================
 

--- a/src/hyppo/dos.asm
+++ b/src/hyppo/dos.asm
@@ -840,6 +840,8 @@ trap_dos_openfile:
 
         +Checkpoint "trap_dos_openfile <success>"
 
+        lda dos_current_file_descriptor
+        sta hypervisor_a
         jmp return_from_trap_with_success
 
 tdof1:

--- a/src/hyppo/main.asm
+++ b/src/hyppo/main.asm
@@ -316,6 +316,14 @@ nosuchtrap:
 
 ;;         ========================
 
+return_from_trap_with_success_and_file_descriptor_in_a:
+
+        lda dos_current_file_descriptor
+        sta hypervisor_a
+        ;; FALL THROUGH to return_from_trap_with_success
+
+;;         ========================
+
 return_from_trap_with_success:
 
         ;; Return from trap with C flag clear to indicate success


### PR DESCRIPTION
`trap_dos_openfile` opens a file descriptor for the file and it's the programmer's responsibility to close it. In order to close it, they need to know what it is.

The A register was chosen to align with `trap_dos_opendir` and `trap_dos_findfirst`.