### PR TITLE
432 bitplanes line offset

### DIFF
--- a/src/vhdl/bitplanes.vhdl
+++ b/src/vhdl/bitplanes.vhdl
@@ -269,7 +269,7 @@ begin  -- behavioural
         v_bitplane_x_start := bitplane_x_start;
       end if;
 
-      if (yfine_in mod 2) = 1 then
+      if (yfine_in mod 2) = 0 then
         v_y_in := y_in;
       else
         v_y_in := y_in + 1;

--- a/src/vhdl/bitplanes.vhdl
+++ b/src/vhdl/bitplanes.vhdl
@@ -268,14 +268,14 @@ begin  -- behavioural
       end if;
 
       -- Pre-calculate some things to improve timing
-      if y_in >= (v_bitplane_y_start + to_integer(signed(std_logic_vector(bitplanes_y_start_drive)))) then
+      if (y_in + 1) >= (v_bitplane_y_start + to_integer(signed(std_logic_vector(bitplanes_y_start_drive)))) then
 --        report "y_in = " & integer'image(y_in);
 --        report "v_bitplane_y_start = " & integer'image(v_bitplane_y_start);
 --        report "bitplane_y_start_drive = " & integer'image(to_integer(signed(std_logic_vector(bitplanes_y_start_drive))));
         bitplane_y_card_position
-          <= integer((y_in - (v_bitplane_y_start + to_integer(signed(std_logic_vector(bitplanes_y_start_drive))))) mod 8);
+          <= integer(((y_in + 1) - (v_bitplane_y_start + to_integer(signed(std_logic_vector(bitplanes_y_start_drive))))) mod 8);
         bitplane_y_card_number_drive
-          <= integer(((y_in - (v_bitplane_y_start + to_integer(signed(std_logic_vector(bitplanes_y_start_drive))))) / 8));
+          <= integer((((y_in + 1) - (v_bitplane_y_start + to_integer(signed(std_logic_vector(bitplanes_y_start_drive))))) / 8));
       else
         bitplane_y_card_position <= 0;
         bitplane_y_card_number_drive <= 0;

--- a/src/vhdl/bitplanes.vhdl
+++ b/src/vhdl/bitplanes.vhdl
@@ -74,6 +74,7 @@ entity bitplanes is
     signal x640_in : in xposition;
     signal x1280_in : in xposition;
     signal y_in : in yposition;
+    signal yfine_in : in yposition;
     signal border_in : in std_logic;
     signal alt_palette_in : in std_logic;
     signal pixel_in : in unsigned(7 downto 0);
@@ -244,6 +245,7 @@ begin  -- behavioural
   -- outputs: colour, is_sprite_out
   main: process (pixelclock) is
     variable v_x_in : integer;
+    variable v_y_in : integer;
     variable v_bitplane_y_start : integer := 0;
     variable v_bitplane_x_start : integer := 0;
   begin  -- process main
@@ -267,15 +269,21 @@ begin  -- behavioural
         v_bitplane_x_start := bitplane_x_start;
       end if;
 
+      if yfine_in(0) ='1' then
+        v_y_in := y_in + 1;
+      else
+        v_y_in := y_in;
+      end if;
+
       -- Pre-calculate some things to improve timing
-      if (y_in + 1) >= (v_bitplane_y_start + to_integer(signed(std_logic_vector(bitplanes_y_start_drive)))) then
+      if v_y_in >= (v_bitplane_y_start + to_integer(signed(std_logic_vector(bitplanes_y_start_drive)))) then
 --        report "y_in = " & integer'image(y_in);
 --        report "v_bitplane_y_start = " & integer'image(v_bitplane_y_start);
 --        report "bitplane_y_start_drive = " & integer'image(to_integer(signed(std_logic_vector(bitplanes_y_start_drive))));
         bitplane_y_card_position
-          <= integer(((y_in + 1) - (v_bitplane_y_start + to_integer(signed(std_logic_vector(bitplanes_y_start_drive))))) mod 8);
+          <= integer((v_y_in - (v_bitplane_y_start + to_integer(signed(std_logic_vector(bitplanes_y_start_drive))))) mod 8);
         bitplane_y_card_number_drive
-          <= integer((((y_in + 1) - (v_bitplane_y_start + to_integer(signed(std_logic_vector(bitplanes_y_start_drive))))) / 8));
+          <= integer(((v_y_in - (v_bitplane_y_start + to_integer(signed(std_logic_vector(bitplanes_y_start_drive))))) / 8));
       else
         bitplane_y_card_position <= 0;
         bitplane_y_card_number_drive <= 0;

--- a/src/vhdl/bitplanes.vhdl
+++ b/src/vhdl/bitplanes.vhdl
@@ -269,7 +269,7 @@ begin  -- behavioural
         v_bitplane_x_start := bitplane_x_start;
       end if;
 
-      if yfine_in(0) ='1' then
+      if (yfine_in mod 2) = 1 then
         v_y_in := y_in + 1;
       else
         v_y_in := y_in;

--- a/src/vhdl/bitplanes.vhdl
+++ b/src/vhdl/bitplanes.vhdl
@@ -270,9 +270,9 @@ begin  -- behavioural
       end if;
 
       if (yfine_in mod 2) = 1 then
-        v_y_in := y_in + 1;
-      else
         v_y_in := y_in;
+      else
+        v_y_in := y_in + 1;
       end if;
 
       -- Pre-calculate some things to improve timing

--- a/src/vhdl/vicii_sprites.vhdl
+++ b/src/vhdl/vicii_sprites.vhdl
@@ -273,6 +273,7 @@ architecture behavioural of vicii_sprites is
   signal yfine_3_2 : yposition;
   signal yfine_2_1 : yposition;
   signal yfine_1_0 : yposition;
+  signal yfine_0_bp : yposition;
   signal border_7_6 : std_logic;
   signal border_6_5 : std_logic;
   signal border_5_4 : std_logic;
@@ -356,7 +357,8 @@ begin
              
              -- Sprite offset data chain for VIC-IV
              sprite_number_for_data_in => sprite_number_for_data_in,
-             sprite_data_offset_in => 0,
+             sprite_data_offset_in
+	      => 0,
              sprite_data_offset_out => sprite_data_offset_7_6,
              sprite_number_for_data_out => sprite_number_for_data_7_6,
 
@@ -434,7 +436,8 @@ begin
 
              -- Sprite offset data chain for VIC-IV
              sprite_number_for_data_in => sprite_number_for_data_7_6,
-             sprite_data_offset_in => sprite_data_offset_7_6,
+             sprite_data_offset_in
+	      => sprite_data_offset_7_6,
              sprite_data_offset_out => sprite_data_offset_6_5,
              sprite_number_for_data_out => sprite_number_for_data_6_5,
 
@@ -513,7 +516,8 @@ begin
 
              -- Sprite offset data chain for VIC-IV
              sprite_number_for_data_in => sprite_number_for_data_6_5,
-             sprite_data_offset_in => sprite_data_offset_6_5,
+             sprite_data_offset_in
+	      => sprite_data_offset_6_5,
              sprite_data_offset_out => sprite_data_offset_5_4,
              sprite_number_for_data_out => sprite_number_for_data_5_4,
 
@@ -599,7 +603,8 @@ begin
 
              -- Sprite offset data chain for VIC-IV
              sprite_number_for_data_in => sprite_number_for_data_5_4,
-             sprite_data_offset_in => sprite_data_offset_5_4,
+             sprite_data_offset_in
+	      => sprite_data_offset_5_4,
              sprite_data_offset_out => sprite_data_offset_4_3,
              sprite_number_for_data_out => sprite_number_for_data_4_3,
 
@@ -678,7 +683,8 @@ begin
 
              -- Sprite offset data chain for VIC-IV
              sprite_number_for_data_in => sprite_number_for_data_4_3,
-             sprite_data_offset_in => sprite_data_offset_4_3,
+             sprite_data_offset_in
+	      => sprite_data_offset_4_3,
              sprite_data_offset_out => sprite_data_offset_3_2,
              sprite_number_for_data_out => sprite_number_for_data_3_2,
 
@@ -757,7 +763,8 @@ begin
              
              -- Sprite offset data chain for VIC-IV
              sprite_number_for_data_in => sprite_number_for_data_3_2,
-             sprite_data_offset_in => sprite_data_offset_3_2,
+             sprite_data_offset_in
+	      => sprite_data_offset_3_2,
              sprite_data_offset_out => sprite_data_offset_2_1,
              sprite_number_for_data_out => sprite_number_for_data_2_1,
 
@@ -836,7 +843,8 @@ begin
              
              -- Sprite offset data chain for VIC-IV
              sprite_number_for_data_in => sprite_number_for_data_2_1,
-             sprite_data_offset_in => sprite_data_offset_2_1,
+             sprite_data_offset_in
+	      => sprite_data_offset_2_1,
              sprite_data_offset_out => sprite_data_offset_1_0,
              sprite_number_for_data_out => sprite_number_for_data_1_0,
 
@@ -915,7 +923,8 @@ begin
 
              -- Sprite offset data chain for VIC-IV
              sprite_number_for_data_in => sprite_number_for_data_1_0,
-             sprite_data_offset_in => sprite_data_offset_1_0,
+             sprite_data_offset_in
+	      => sprite_data_offset_1_0,
              sprite_data_offset_out => sprite_data_offset_0_bp,
              sprite_number_for_data_out => sprite_number_for_data_0_bp,
 
@@ -1007,7 +1016,8 @@ begin
              
              -- Sprite offset data chain for VIC-IV
              sprite_number_for_data_in => sprite_number_for_data_0_bp,
-             sprite_data_offset_in => sprite_data_offset_0_bp,
+             sprite_data_offset_in
+	      => sprite_data_offset_0_bp,
              sprite_data_offset_out => sprite_data_offset_out,
              sprite_number_for_data_out => sprite_number_for_data_out,
 
@@ -1018,6 +1028,7 @@ begin
              x640_in => x640_0_bp,
              x1280_in => x640_0_bp,
              y_in => y_0_bp,
+	     yfine_in => yfine_0_bp,
              border_in => border_0_bp,
              alt_palette_in => alt_palette_0_bp,
              pixel_in => pixel_0_bp,

--- a/src/vhdl/vicii_sprites.vhdl
+++ b/src/vhdl/vicii_sprites.vhdl
@@ -949,6 +949,7 @@ begin
              is_background_out => is_background_0_bp,
              x320_out => x320_0_bp,
              x640_out => x640_0_bp,
+	     yfine_out => yfine_0_bp,
              y_out => y_0_bp,
              border_out => border_0_bp,
              alt_palette_out => alt_palette_0_bp,

--- a/src/vhdl/viciv.vhdl
+++ b/src/vhdl/viciv.vhdl
@@ -4923,7 +4923,7 @@ begin
             end if;
             -- Interlacing selects which of two bitplane address register
             -- fields to use
-            if (reg_v400='1') and (vicii_ycounter_v400(0)='1') then
+            if (reg_v400='1') and (vicii_ycounter_v400(0)='0') then
               -- Use odd scan set
               sprite_pointer_address(15 downto 13)
                 <= bitplane_addresses(sprite_fetch_sprite_number mod 8)


### PR DESCRIPTION
As noted in issue #432 the fix tries to read the data early enough for the rendering procedure, so one physical (interlaced) line earlier. This leads the fact that odd/even ram source selection when fetching the data get inverted but in result ithe output is correct in my testings. To make this I also have to pass pyhsical (interlaced) line info into the bitplances component. 