### PR TITLE
415 pixel poo

### DIFF
--- a/src/vhdl/bitplanes.vhdl
+++ b/src/vhdl/bitplanes.vhdl
@@ -254,15 +254,15 @@ begin  -- behavioural
       bitplane_data_offsets <= bitplane_data_offsets_next;
 
       if bitplane_h640='1' then
-        v_x_in := x640_in;
+        v_x_in := x640_in + 1;
         v_bitplane_y_start := bitplane_y_start_h640;
         v_bitplane_x_start := bitplane_x_start_h640;
       elsif bitplane_h1280='1' then
-        v_x_in := x1280_in;
+        v_x_in := x1280_in + 1;
         v_bitplane_y_start := bitplane_y_start_h1820;
         v_bitplane_x_start := bitplane_x_start_h1280;
       else
-        v_x_in := x_in;
+        v_x_in := x_in + 1;
         v_bitplane_y_start := bitplane_y_start;
         v_bitplane_x_start := bitplane_x_start;
       end if;

--- a/src/vhdl/bitplanes.vhdl
+++ b/src/vhdl/bitplanes.vhdl
@@ -254,17 +254,17 @@ begin  -- behavioural
       bitplane_data_offsets <= bitplane_data_offsets_next;
 
       if bitplane_h640='1' then
-        v_x_in := x640_in + 1;
+        v_x_in := x640_in;
         v_bitplane_y_start := bitplane_y_start_h640;
-        v_bitplane_x_start := bitplane_x_start_h640;
+        v_bitplane_x_start := bitplane_x_start_h640 + 10;
       elsif bitplane_h1280='1' then
-        v_x_in := x1280_in + 1;
+        v_x_in := x1280_in;
         v_bitplane_y_start := bitplane_y_start_h1820;
-        v_bitplane_x_start := bitplane_x_start_h1280;
+        v_bitplane_x_start := bitplane_x_start_h1280 + 10;
       else
-        v_x_in := x_in + 1;
+        v_x_in := x_in;
         v_bitplane_y_start := bitplane_y_start;
-        v_bitplane_x_start := bitplane_x_start;
+        v_bitplane_x_start := bitplane_x_start + 10;
       end if;
 
       -- Pre-calculate some things to improve timing

--- a/src/vhdl/bitplanes.vhdl
+++ b/src/vhdl/bitplanes.vhdl
@@ -147,6 +147,7 @@ architecture behavioural of bitplanes is
   signal x_left : std_logic := '0';
   signal y_top : std_logic := '0';
   signal x_in_bitplanes : std_logic := '0';
+  signal x_in_bitplanes_drive : std_logic := '0';
   signal last_x_in_bitplanes : std_logic := '0';
   signal bitplane_drawing : std_logic := '0';
   signal bitplane_drawing_next : std_logic := '0';
@@ -398,7 +399,7 @@ begin  -- behavioural
       if v_x_in = (v_bitplane_x_start + to_integer(signed(std_logic_vector(bitplanes_x_start))))
         and (y_top='1' or bitplane_drawing='1') then
         x_left <= '1';
-        x_in_bitplanes <= '1';
+        x_in_bitplanes_drive <= '1';
         if (v_x_in /= x_last) then
           bitplanes_advance_pixel <= "11111111";
         end if;
@@ -409,22 +410,23 @@ begin  -- behavioural
 
       if bitplane_h640 = '1' and bitplane_h1280 = '1' then
         if v_x_in >= (v_bitplane_x_start + to_integer(signed(std_logic_vector(bitplanes_x_start))) + 800) then
-          x_in_bitplanes <= '0';
+          x_in_bitplanes_drive <= '0';
         end if;
       elsif bitplane_h640 = '1' then
         if v_x_in >= (v_bitplane_x_start + to_integer(signed(std_logic_vector(bitplanes_x_start))) + 640) then
-          x_in_bitplanes <= '0';
+          x_in_bitplanes_drive <= '0';
         end if;
       elsif bitplane_h1280 = '1' then
         if v_x_in >= (v_bitplane_x_start + to_integer(signed(std_logic_vector(bitplanes_x_start))) + 1280) then
-          x_in_bitplanes <= '0';
+          x_in_bitplanes_drive <= '0';
         end if;
       else
         if v_x_in >= (v_bitplane_x_start + to_integer(signed(std_logic_vector(bitplanes_x_start))) + 320) then
-          x_in_bitplanes <= '0';
+          x_in_bitplanes_drive <= '0';
         end if;
       end if;
       -- Clear bitplane byte numbers at the end of each raster
+      x_in_bitplanes <= x_in_bitplanes_drive;
       last_x_in_bitplanes <= x_in_bitplanes;
       if x_in_bitplanes = '0' and last_x_in_bitplanes = '1' then
         report "Hit right border. Flushing buffered bytes in all bitplanes";

--- a/src/vhdl/bitplanes.vhdl
+++ b/src/vhdl/bitplanes.vhdl
@@ -257,15 +257,15 @@ begin  -- behavioural
       if bitplane_h640='1' then
         v_x_in := x640_in;
         v_bitplane_y_start := bitplane_y_start_h640;
-        v_bitplane_x_start := bitplane_x_start_h640 + 10;
+        v_bitplane_x_start := bitplane_x_start_h640;
       elsif bitplane_h1280='1' then
         v_x_in := x1280_in;
         v_bitplane_y_start := bitplane_y_start_h1820;
-        v_bitplane_x_start := bitplane_x_start_h1280 + 10;
+        v_bitplane_x_start := bitplane_x_start_h1280;
       else
         v_x_in := x_in;
         v_bitplane_y_start := bitplane_y_start;
-        v_bitplane_x_start := bitplane_x_start + 10;
+        v_bitplane_x_start := bitplane_x_start;
       end if;
 
       -- Pre-calculate some things to improve timing


### PR DESCRIPTION
I'm delaying the start of the rendering of the bitplane by one physical pixel to ensure required data is in place. Not sure why this depends on the pal simluation option. Now bitplains are alway one phyisical pixel to the right, but rendering so to be fine.