### PR TITLE
Resolves #505 - division is off by a bit

### DIFF
--- a/src/vhdl/fast_divide.vhdl
+++ b/src/vhdl/fast_divide.vhdl
@@ -20,7 +20,7 @@ entity fast_divide is
 end entity;
 
 architecture wattle_and_daub of fast_divide is
-  type state_t is (idle, normalise, step, output);
+  type state_t is (idle, normalise, step, preoutput, output);
   signal state : state_t := idle;
   signal steps_remaining : integer range 0 to 5 := 0;
 
@@ -102,15 +102,18 @@ begin
           if steps_remaining /= 0 and dd /= x"FFFFFFFFF" then
             steps_remaining <= steps_remaining - 1;
           else
-            state <= output;
+            state <= preoutput;
           end if;
-        when output =>
-          busy <= '0';
+        when preoutput =>
           -- No idea why we need to add one, but we do to stop things like 4/2
           -- giving a result of 1.999999999
-          temp64(67 downto 0) := nn + 1;
+          temp64(67 downto 0) := nn;
           temp64(73 downto 68) := (others => '0');
+          temp64 := temp64 + 1;
           report "temp64=$" & to_hstring(temp64);
+          state <= output;
+        when output =>
+          busy <= '0';
           q <= temp64(67 downto 4);
           state <= idle;
       end case;

--- a/tests/hardware_divider.vhdl
+++ b/tests/hardware_divider.vhdl
@@ -35,7 +35,8 @@ architecture tb of tb_example is
   signal v : test_vectors := (
     0 => (n=>x"00000001",d=>x"00000040",q_expected=>x"0000000004000000"),
     1 => (n=>x"00000001",d=>x"00000100",q_expected=>x"0000000001000000"),
-    2 => (n=>x"00000001",d=>x"00000064",q_expected=>x"00000000028f5c28"),
+    2 => (n=>x"80000000",d=>x"C0000000",q_expected=>x"00000000AAAAAAAA"),
+    --2 => (n=>x"00000001",d=>x"00000064",q_expected=>x"00000000028f5c28"),
     others => (n=>to_unsigned(0,32), d=>to_unsigned(0,32), q_expected=>to_unsigned(0,64)));
   
 begin


### PR DESCRIPTION
The problem is that there divisions which need the last +1 to the result and there are some that don't need it (from a BASIC point of view).

So:
$1/$40 = $0000000004000000
but the hardware dividers result (before the +1 in the output step) is
$1/$40 = $0000000003FFFFFF
so it needs the +1

On the other hand
$80000000/$C0000000 = $00000000AAAAAAAA
here the hardware dividers result (include the +1 of the output step) is
$80000000/$C0000000 = $00000000AAAAAAAB
which is one to much.

To solve this, this pull request expands all internal registers by 4 bit at the LSB side.
This produces the correct (expected?) results.

Example:
$80000000/$C0000000 = $00000000AAAAAAAA.A
output step:
$80000000/$C0000000 = $00000000AAAAAAAA.B
return value without the last 4 bit:
$80000000/$C0000000 = $00000000AAAAAAAA

And:
$1/$40 = $0000000003FFFFFF.F
output step:
$1/$40 = $0000000004000000.0
return value without the last 4 bit:
$1/$40 = $0000000004000000

Tested by me and by Bit Shifter with 920283.