### PR TITLE
Improve "raw" keys

### DIFF
--- a/src/vhdl/c65uart.vhdl
+++ b/src/vhdl/c65uart.vhdl
@@ -512,7 +512,7 @@ begin  -- behavioural
             -- @IO:GS $D611.0 WRITE ONLY Connect POT lines to IEC port (for r1 PCB only)
             pot_via_iec <= fastio_wdata(0);
             -- @IO:GS $D611.1 WRITE ONLY enable real joystick ports (for r2 PCB only)
-            joyreal_enable_internal <= fastio_wdata(1);
+            -- joyreal_enable_internal <= fastio_wdata(1);
             matrix_disable_modifiers <= fastio_wdata(7);
           when x"12" =>
             widget_enable_internal <= std_logic(fastio_wdata(0));

--- a/src/vhdl/iomapper.vhdl
+++ b/src/vhdl/iomapper.vhdl
@@ -134,6 +134,9 @@ entity iomapper is
         porta_pins : inout  std_logic_vector(7 downto 0) := (others => 'Z');
         portb_pins : in  std_logic_vector(7 downto 0);
         keyboard_column8_out : out std_logic;
+
+        key_cbm : in std_logic;
+
         key_left : in std_logic;
         key_up : in std_logic;
 
@@ -927,6 +930,9 @@ begin
     restore_out => restore_nmi,
     keyboard_restore => restore_key,
     keyboard_capslock => capslock_key,
+    
+    key_cbm => key_cbm,
+    
     key_left => key_left,
     key_up => key_up,
 

--- a/src/vhdl/keyboard_complex.vhdl
+++ b/src/vhdl/keyboard_complex.vhdl
@@ -22,6 +22,9 @@ entity keyboard_complex is
     scan_rate : in unsigned(7 downto 0);
     keyboard_restore : in std_logic := '1';
     keyboard_column8_out : out std_logic := '1';
+    
+    key_cbm : in std_logic;
+    
     key_left : in std_logic;
     key_up : in std_logic;
     keyboard_capslock : in std_logic;
@@ -223,6 +226,8 @@ begin
     capslock_physkey => keyboard_capslock,
     restore_physkey => keyboard_restore,
     restore_virtual => virtual_restore,
+
+    cbm_physkey => key_cbm,
 
     joykey_disable => joykey_disable,
     joya_physkey => keyboard_joya,

--- a/src/vhdl/keymapper.vhdl
+++ b/src/vhdl/keymapper.vhdl
@@ -24,6 +24,9 @@ entity keymapper is
     physkey_disable : in std_logic;
     matrix_col_physkey : in std_logic_vector(7 downto 0);
     capslock_physkey : in std_logic;
+    
+    cbm_physkey : in std_logic;
+    
     restore_physkey : in std_logic;
     restore_virtual : in std_logic;
 
@@ -333,7 +336,7 @@ begin  -- behavioural
           if restore_down_ticks < 8 then
             -- <0.25 seconds = quick tap = trigger NMI
             restore_out <= '0';
-          elsif restore_down_ticks < 128 then
+          elsif (restore_down_ticks < 128) and (cbm_physkey = '0') then
             -- 0.25 - ~ 4 second hold = trigger hypervisor trap
             hyper_trap_on_frame_sync <= '1';
 --          elsif restore_down_ticks < 128 then

--- a/src/vhdl/machine.vhdl
+++ b/src/vhdl/machine.vhdl
@@ -168,6 +168,7 @@ entity machine is
          -------------------------------------------------------------------------
          porta_pins : inout  std_logic_vector(7 downto 0) := (others => 'Z');
          portb_pins : in  std_logic_vector(7 downto 0);
+         keycbm : in std_logic;
          keyleft : in std_logic;
          keyup : in std_logic;
          keyboard_column8 : out std_logic := '1';
@@ -1681,6 +1682,9 @@ begin
       portb_pins => portb_pins,
       capslock_key => caps_lock_key,
       keyboard_column8_out => keyboard_column8,
+      
+      key_cbm => keycbm,
+      
       key_left => keyleft,
       key_up => keyup,
 

--- a/src/vhdl/matrix_to_ascii.vhdl
+++ b/src/vhdl/matrix_to_ascii.vhdl
@@ -609,7 +609,14 @@ begin
           key_matrix := matrix_normal;
         end if;
       else
-        key_matrix := matrix_normal;
+          if bucky_key_internal(3)='1' then
+                case key_num is
+                    when 65 => key_matrix := matrix_cbm;
+                    when others => key_matrix := matrix_normal;
+                end case;                
+          else
+                key_matrix := matrix_normal;
+          end if;
       end if;
         
 

--- a/src/vhdl/mega65kbd_to_matrix.vhdl
+++ b/src/vhdl/mega65kbd_to_matrix.vhdl
@@ -36,6 +36,8 @@ entity mega65kbd_to_matrix is
     restore : out std_logic := '1';
     capslock_out : out std_logic := '1';
 
+    cbmkey: out std_logic := '1';
+    
     -- LEFT and UP cursor keys are active HIGH
     leftkey : out std_logic := '0';
     upkey : out std_logic := '0'
@@ -116,6 +118,10 @@ begin  -- behavioural
           keyram_offset := phase/8;
 
           -- Receive keys with dedicated lines
+          if phase = 61 then
+            cbmkey <= kio10;
+          end if;
+                    
           if phase = 72 then
             capslock_out <= kio10;
           end if;

--- a/src/vhdl/mega65r2.vhdl
+++ b/src/vhdl/mega65r2.vhdl
@@ -272,6 +272,9 @@ architecture Behavioral of container is
 
   -- XXX Actually connect to new keyboard
   signal restore_key : std_logic := '1';
+
+  signal keycbm : std_logic := '1';
+
   -- XXX Note that left and up are active HIGH!
   -- XXX Plumb these into the MEGA65R2 keyboard protocol receiver
   signal keyleft : std_logic := '0';
@@ -521,6 +524,9 @@ begin
       restore => widget_restore,
       fastkey_out => fastkey,
       capslock_out => widget_capslock,
+      
+      cbmkey => keycbm,
+      
       upkey => keyup,
       leftkey => keyleft
       
@@ -751,6 +757,7 @@ begin
       portb_pins => row(7 downto 0),
       keyboard_column8 => column(8),
       caps_lock_key => '1',
+      keycbm => keycbm,
       keyleft => keyleft,
       keyup => keyup,
 

--- a/src/vhdl/nexys4.vhdl
+++ b/src/vhdl/nexys4.vhdl
@@ -183,6 +183,12 @@ architecture Behavioral of container is
   signal cpu_game : std_logic := '1';
   signal cpu_exrom : std_logic := '1';
   
+  --DENGLAND This will make it such that the CBM keys is considered down when
+  -- checking for freezer key
+  
+  signal keycbm : std_logic := '0';
+
+  
   signal buffer_vgared : unsigned(7 downto 0);
   signal buffer_vgagreen : unsigned(7 downto 0);
   signal buffer_vgablue : unsigned(7 downto 0);
@@ -435,6 +441,9 @@ begin
       irq => irq,
       nmi => nmi,
       restore_key => restore_key,
+      
+      keycbm => keycbm,  
+      
       sector_buffer_mapped => sector_buffer_mapped,
 
       qspi_clock => qspi_clock,

--- a/src/vhdl/nexys4ddr-widget.vhdl
+++ b/src/vhdl/nexys4ddr-widget.vhdl
@@ -179,6 +179,7 @@ architecture Behavioral of container is
   signal irq : std_logic := '1';
   signal nmi : std_logic := '1';
   signal restore_key : std_logic := '1';
+  signal keycbm : std_logic := '1';
   signal reset_out : std_logic := '1';
   signal cpu_game : std_logic := '1';
   signal cpu_exrom : std_logic := '1';
@@ -360,6 +361,9 @@ begin
     matrix_col_idx => widget_matrix_col_idx,
     restore => widget_restore,
     capslock_out => widget_capslock,
+    
+    cbmkey => keycbm,
+    
     joya => widget_joya,
     joyb => widget_joyb
     );  
@@ -436,6 +440,8 @@ begin
       nmi => nmi,
       restore_key => restore_key,
       sector_buffer_mapped => sector_buffer_mapped,
+
+      keycbm => keycbm,
 
       qspi_clock => qspi_clock,
       qspicsn => qspicsn,
@@ -578,6 +584,7 @@ begin
       widget_joya => widget_joya,
       widget_joyb => widget_joyb,      
       
+    
       uart_rx => jclo(1),
       uart_tx => jclo(2),
 

--- a/src/vhdl/nexys4ddr.vhdl
+++ b/src/vhdl/nexys4ddr.vhdl
@@ -182,6 +182,12 @@ architecture Behavioral of container is
   signal irq : std_logic := '1';
   signal nmi : std_logic := '1';
   signal restore_key : std_logic := '1';
+  
+  --DENGLAND This will make it such that the CBM keys is considered down when
+  -- checking for freezer key
+  
+  signal keycbm : std_logic := '0';
+  
   signal reset_out : std_logic := '1';
   signal cpu_game : std_logic := '1';
   signal cpu_exrom : std_logic := '1';
@@ -403,6 +409,9 @@ begin
       irq => irq,
       nmi => nmi,
       restore_key => restore_key,
+      
+      keycbm => keycbm,      
+      
       sector_buffer_mapped => sector_buffer_mapped,
 
       joy3 => joy3,

--- a/src/vhdl/widget_to_matrix.vhdl
+++ b/src/vhdl/widget_to_matrix.vhdl
@@ -16,6 +16,10 @@ entity widget_to_matrix is
     matrix_col : out std_logic_vector(7 downto 0) := (others => '1');
     matrix_col_idx : in integer range 0 to 8;
     
+ --DENGLAND This will effectively say, for the sake of freezing, that the
+ --  cbm key is always down.
+    cbmkey : out std_logic := '0';
+    
     restore : out std_logic := '1';
     capslock_out : out std_logic := '1';
     reset_out : out std_logic := '1';

--- a/src/vhdl/wukong.vhdl
+++ b/src/vhdl/wukong.vhdl
@@ -194,6 +194,10 @@ architecture Behavioral of container is
   signal column : std_logic_vector(8 downto 0) := (others => '1');
   signal row : std_logic_vector(7 downto 0) := (others => '1');
   
+  --DENGLAND This will make the CBM key be down for the freeze key test
+  
+  signal keycbm : std_logic := '0';
+  
   
   signal segled_counter : unsigned(31 downto 0) := (others => '0');
 
@@ -715,6 +719,8 @@ begin
       nmi => nmi_combined,
       restore_key => restore_key,
       sector_buffer_mapped => sector_buffer_mapped,
+
+      keycbm => keycbm,        
 
       qspi_clock => qspi_clock,
       qspicsn => qspicsn,


### PR DESCRIPTION
- Fix issue whereby setting $D611.7 causes matrix mode to become inaccessible
- Fix issue whereby setting $D611 causes mouse on R2 to become inoperable
- Change RESTORE (HOLD) sequence to freeze to be instead MEGA + RESTORE (HOLD) (r2 only!)