### PR TITLE
If holding down ESCAPE key on cold power-up, perform an early endless loop

### DIFF
--- a/src/hyppo/dos.asm
+++ b/src/hyppo/dos.asm
@@ -3132,6 +3132,10 @@ drce_end_of_sector:
         sta dos_file_descriptors+dos_filedescriptor_offset_offsetinsector+1,y
 
         jsr dos_file_advance_to_next_sector
+        ; since we've changed sectors, read in new sector data
+        bcc @skipreadsector
+        jsr dos_file_read_current_sector
+@skipreadsector:
         rts
 
 ;;         ========================
@@ -3342,8 +3346,6 @@ dfatns1:
         ;;
         beq dos_file_advance_to_next_cluster
 
-        ; since we've changed sectors, read in new sector data
-        jsr dos_file_read_current_sector
         sec
         rts
 

--- a/src/hyppo/main.asm
+++ b/src/hyppo/main.asm
@@ -712,6 +712,31 @@ fpga_has_been_reconfigured:
 
 normalboot:
 
+; add a test if the TAB key is held down
+; if so, make an endless loop so that a person debugging
+; and turn trace mode on, move the pc (with 'g<addr>') to skip
+; over the loop and then comfortably step through early
+; hypervisor code.
+        ldx #$ff    ;; make a few attempts are reading keyscan early
+
+@earlyscan:
+        jsr scankeyboard
+        bcc @earlycheckkey
+        
+        dex     ;; no key pressed yet
+        bne @earlyscan
+        jmp @skipearlycheck  ;; no key was pressed, despite looping for a while to wait for it
+
+@earlycheckkey:
+        cmp #$1f    ;; was HELP key pressed?
+        bne @skipearlycheck
+
+@loopendlessly
+        inc $d020
+        jmp @loopendlessly
+
+@skipearlycheck:
+
 !if DEBUG_HYPPO {
         jsr dump_disk_count        ;; debugging to Checkpoint
         jsr dumpcurrentfd        ;; debugging to Checkpoint

--- a/src/hyppo/main.asm
+++ b/src/hyppo/main.asm
@@ -728,7 +728,7 @@ normalboot:
         jmp @skipearlycheck  ;; no key was pressed, despite looping for a while to wait for it
 
 @earlycheckkey:
-        cmp #$1f    ;; was HELP key pressed?
+        cmp #$03    ;; was RUN-STOP key pressed?
         bne @skipearlycheck
 
 @loopendlessly

--- a/src/hyppo/main.asm
+++ b/src/hyppo/main.asm
@@ -728,7 +728,7 @@ normalboot:
         jmp @skipearlycheck  ;; no key was pressed, despite looping for a while to wait for it
 
 @earlycheckkey:
-        cmp #$03    ;; was RUN-STOP key pressed?
+        cmp #$1b    ;; was ESCAPE key pressed?
         bne @skipearlycheck
 
 @loopendlessly


### PR DESCRIPTION
(to allow for early debugging of hyppo issues)

Also includes a repair to dos.asm to get manche working again.