### PR TITLE
Hyppo fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@ src/monitor/gen_dis
 src/tools/ftphelper.c
 src/hyppo/HICKUP.*
 exomized.prg
-iomap.txt
 
 # ophis
 src/*.list

--- a/src/hyppo/freeze.asm
+++ b/src/hyppo/freeze.asm
@@ -1017,7 +1017,7 @@ freeze_mem_list:
         ;; XXX - These can't be read by DMA, so we need to have a
         ;; prep routine that copies them out first?
         !32 $ffd3640
-        !16 $003f
+        !16 $003e
         !8 0
         !8 freeze_prep_hyperregs
 

--- a/src/hyppo/freeze.asm
+++ b/src/hyppo/freeze.asm
@@ -64,6 +64,12 @@ unfreeze_next_region:
 
         jsr unfreeze_load_region
 
+        ;; Re-enable M65 IO in case we wrote over the key register during the region unfreeze
+        lda #$47
+        sta $d02f
+        lda #$53
+        sta $d02f
+
         txa
         clc
         adc #$08

--- a/src/hyppo/freeze.asm
+++ b/src/hyppo/freeze.asm
@@ -65,6 +65,12 @@ unfreeze_next_region:
         jsr unfreeze_load_region
 
         ;; Re-enable M65 IO in case we wrote over the key register during the region unfreeze
+        ;; NOTE: This usage was re-instated after deleting it cause exiting the freeze-menu to
+        ;; either stall in BASIC (in an endless loop awaiting for the sd-card to be ready) for
+        ;; some users, or causing DIR to return 'Drive not ready' for other users.
+        ;; The exact reason behind the impact of its removal isn't known and warrants further
+        ;; investigation at some stage. See this past Discord thread for more details:
+        ;; https://discord.com/channels/719326990221574164/791383472853614593/982994187681161278
         lda #$47
         sta $d02f
         lda #$53

--- a/src/vhdl/gs4510.vhdl
+++ b/src/vhdl/gs4510.vhdl
@@ -4721,7 +4721,7 @@ begin
           watchdog_fed <= '1';
         end if;
                                         -- @IO:GS $D67E HCPU:HICKED Hypervisor already-upgraded bit (writing sets permanently)
-        if last_write_address = x"FFD367E" and hypervisor_mode='1' then
+        if last_write_address = x"FFD367E" and hypervisor_mode='1' and pending_dma_busy = '0' then
           hypervisor_upgraded <= '1';
         end if;
 

--- a/src/vhdl/gs4510.vhdl
+++ b/src/vhdl/gs4510.vhdl
@@ -4721,7 +4721,7 @@ begin
           watchdog_fed <= '1';
         end if;
                                         -- @IO:GS $D67E HCPU:HICKED Hypervisor already-upgraded bit (writing sets permanently)
-        if last_write_address = x"FFD367E" and hypervisor_mode='1' and pending_dma_busy = '0' then
+        if last_write_address = x"FFD367E" and hypervisor_mode='1' then
           hypervisor_upgraded <= '1';
         end if;
 


### PR DESCRIPTION
- un-ignoring iomap.txt, as people find that a useful reference
- reverted recent change in hyppo's 'freeze.asm' (removal of D02F knock) which was impacting exit out of freezer
- trying to avoid touching HICKED register during un-freezing DMA calls, to prevent accidental HICKED message on resets
- updated freezer menu's version to 0.1.6 (to avoid recent versioning confusion between filehost and github repo)