### PR TITLE
rrb gotox is off by 1 #337

### DIFF
--- a/src/vhdl/viciv.vhdl
+++ b/src/vhdl/viciv.vhdl
@@ -4702,7 +4702,7 @@ begin
               -- Glyph is tab-stop glyph
               -- Set screen ram buffer write address to 10 bit
               -- offset indicated by glyph number bits
-              raster_buffer_write_address(9 downto 0) <= glyph_number(9 downto 0);
+              raster_buffer_write_address(9 downto 0) <= glyph_number(9 downto 0) - 1;
 
               if glyph_4bit='1' then
                 screenline_draw_mask <= screenline_draw_mask;


### PR DESCRIPTION
This PR fixes X positions in RRB GOTOX being one pixel off to the right. The fix may be important once programs rely on pixel exact positioning of RRB layers, and developers should not be encouraged to work around that bug by intentionally positioning their layers one pixel off.