### PR TITLE
fix mix-up of two rx eth frames when buffers are full

### DIFF
--- a/src/vhdl/ethernet.vhdl
+++ b/src/vhdl/ethernet.vhdl
@@ -625,9 +625,7 @@ begin  -- behavioural
       -- Double flip-flop latch the eth_tx_trigger
       eth_tx_trigger_50mhz_drive <= eth_tx_trigger_drive;
       eth_tx_trigger_50mhz <= eth_tx_trigger_50mhz_drive;
-      
-      eth_rx_blocked_50mhz <= eth_rx_blocked;
-      
+          
       eth_txd_phase_drive <= eth_txd_phase;
       eth_rx_latch_phase_drive <= eth_rx_latch_phase;
       
@@ -946,6 +944,10 @@ begin  -- behavioural
               eth_frame_len <= 2;
               eth_mac_counter <= 0;
               eth_bit_count <= 0;
+              -- Only decide on frame rejection at the beginning of the frame
+              -- to avoid starting writing half frames to the rx buffer in
+              -- case the cpu frees up a buffer in the middle of reception
+              eth_rx_blocked_50mhz <= eth_rx_blocked;
             end if;
           when DebugRxFrameWait =>
             if debug_rx = '0' then


### PR DESCRIPTION
There is the eth_rx_blocked_50mhz signal preventing that new bytes received are written to the buffers in case all rx buffers are full. If in the middle of such an "ignored" packet the CPU frees up one more buffer then that signal is set immediately, and the state machine continues writing bytes into the now free buffer. This leads to a buffer containing partly old and partly new data, thus garbage. The CRC32 is not detecting this because it is not applied on the rx buffer bytes but on the bits received from the transceiver.