### PR TITLE
Fix for WARNING: 'open_hw' is deprecated, please use 'open_hw_manager' instead

### DIFF
--- a/nexys4ddr-write-flash.tcl
+++ b/nexys4ddr-write-flash.tcl
@@ -1,4 +1,4 @@
-open_hw
+open_hw_manager
 connect_hw_server
 open_hw_target
 create_hw_cfgmem -hw_device [lindex [get_hw_devices xc7a100t_0] 0] [lindex [get_cfgmem_parts {s25fl128sxxxxxx0-spi-x1_x2_x4}] 0]


### PR DESCRIPTION
Use open_hw_manager in nexys4ddr-write-flash.tcl to avoid that "benign" warning.