### PR TITLE
1BitSquarred HyperRAM-quad support for nexys4ddr-widget target

### DIFF
--- a/src/vhdl/nexys4ddr-widget.vhdl
+++ b/src/vhdl/nexys4ddr-widget.vhdl
@@ -337,7 +337,7 @@ architecture Behavioral of container is
   signal kbd_matrix_col : std_logic_vector(7 downto 0) := (others => '1');
   signal kbd_restore : std_logic;
   signal kbd_capslock : std_logic;
-  signal kbd_disable : std_logic := '0';
+  signal kbd_disable : std_logic := '1';
 
   signal widget_matrix_col_idx : integer range 0 to 8 := 0;
   signal widget_matrix_col : std_logic_vector(7 downto 0) := (others => '1');
@@ -345,7 +345,7 @@ architecture Behavioral of container is
   signal widget_capslock : std_logic;
   signal widget_joya : std_logic_vector(4 downto 0);
   signal widget_joyb : std_logic_vector(4 downto 0);
-  signal widget_disable : std_logic := '0';
+  signal widget_disable : std_logic := '1';
 
   signal com_matrix_col_idx : integer range 0 to 8 := 0;
   signal com_matrix_col : std_logic_vector(7 downto 0);
@@ -554,16 +554,16 @@ begin
       hr_clk_n => hr_clk_n,
 
       hr_cs0 => hr_cs0,
-      hr_cs1 => hr_cs1,
+      -- hr_cs1 => hr_cs1,
       -- hr_cs2 => hr_cs2,
       -- hr_cs3 => hr_cs3,
 
       hr2_d => open,
       hr2_rwds => open
---      hr2_reset => hr2_reset,
---      hr2_clk_p => hr2_clk_p
---      hr_clk_n => hr_clk_n,
---      hr_cs1 => hr2_cs0
+      -- hr2_reset => hr2_reset,
+      -- hr2_clk_p => hr2_clk_p
+      -- hr_clk_n => hr_clk_n,
+      -- hr_cs1 => hr2_cs0
       );
 
   slow_devices0: entity work.slow_devices
@@ -697,11 +697,17 @@ begin
         --   fa_down => jchi(7),
         --   fa_right => jchi(8),
 
-          fb_fire => '1',
-          fb_up =>   '1',
-          fb_left => '1',
-          fb_down => '1',
-          fb_right =>'1',
+        --   fb_fire => '1',
+        --   fb_up =>   '1',
+        --   fb_left => '1',
+        --   fb_down => '1',
+        --   fb_right =>'1',
+
+          fb_fire => widget_joyb(4),
+          fb_up =>   widget_joyb(0),
+          fb_left => widget_joyb(1),
+          fb_down => widget_joyb(2),
+          fb_right =>widget_joyb(3),
 
           fa_potx => '0',
           fa_poty => '0',
@@ -900,9 +906,9 @@ begin
   com_matrix_col <=
                     "11111111"
                     and (widget_matrix_col or (7 downto 0 => widget_disable))
-                    and (kbd_matrix_col or (7 downto 0 => kbd_disable));
-  com_restore <= '1' and (kbd_restore or kbd_disable) and (widget_restore or widget_disable);
-  com_capslock <= '1'and (kbd_capslock or kbd_disable) and (widget_capslock or widget_disable);
+                    and (kbd_matrix_col    or (7 downto 0 => kbd_disable));
+  com_restore  <= '1' and (kbd_restore  or kbd_disable) and (widget_restore  or widget_disable);
+  com_capslock <= '1' and (kbd_capslock or kbd_disable) and (widget_capslock or widget_disable);
 
   process (cpuclock,pixelclock,cpuclock,pal50_select)
   begin
@@ -956,11 +962,20 @@ begin
         end if;
       end if;
 
-      if widget_matrix_col = x"FF" then
-        widget_disable <= '1';
-      elsif kbd_matrix_col = x"FF" then
-        kbd_disable <= '1';
+    end if;
+
+    if rising_edge(cpuclock) then
+
+      if (widget_matrix_col/=x"FF" and widget_disable='1') then
+        widget_disable <= '0';
       end if;
+      if (kbd_matrix_col/=x"FF" and kbd_disable='1') then
+        kbd_disable <= '0';
+      end if;
+
+    end if;
+
+    if rising_edge(cpuclock) then
 
       -- Detect MK-I keyboard by looking for KIO10 going high, as MK-II keyboard
       -- holds this line forever low.  As MK-I will start with KIO10 high, we can
@@ -984,6 +999,7 @@ begin
           end if;
         end if;
       end if;
+
     end if;
 
     if mk1_connected='1' then
@@ -1014,6 +1030,7 @@ begin
       mk2_xil_io2 <= xil_io2;
       xil_io3 <= mk2_xil_io3;
     end if;
+
   end process;
 
 end Behavioral;

--- a/src/vhdl/nexys4ddr-widget.vhdl
+++ b/src/vhdl/nexys4ddr-widget.vhdl
@@ -558,8 +558,8 @@ begin
       -- hr_cs2 => hr_cs2,
       -- hr_cs3 => hr_cs3,
 
-      hr2_d => hr_d,
-      hr2_rwds => hr_rwds
+      hr2_d => open,
+      hr2_rwds => open
 --      hr2_reset => hr2_reset,
 --      hr2_clk_p => hr2_clk_p
 --      hr_clk_n => hr_clk_n,

--- a/src/vhdl/nexys4ddr-widget.vhdl
+++ b/src/vhdl/nexys4ddr-widget.vhdl
@@ -1,20 +1,20 @@
 ----------------------------------------------------------------------------------
--- Company: 
--- Engineer: 
--- 
--- Create Date:    22:30:37 12/10/2013 
--- Design Name: 
--- Module Name:    container - Behavioral 
--- Project Name: 
--- Target Devices: 
--- Tool versions: 
--- Description: 
+-- Company:
+-- Engineer:
 --
--- Dependencies: 
+-- Create Date:    22:30:37 12/10/2013
+-- Design Name:
+-- Module Name:    container - Behavioral
+-- Project Name:
+-- Target Devices:
+-- Tool versions:
+-- Description:
 --
--- Revision: 
+-- Dependencies:
+--
+-- Revision:
 -- Revision 0.01 - File Created
--- Additional Comments: 
+-- Additional Comments:
 --
 ----------------------------------------------------------------------------------
 library IEEE;
@@ -33,17 +33,17 @@ library UNISIM;
 use UNISIM.VComponents.all;
 
 entity container is
-  Port ( CLK_IN : STD_LOGIC;         
+  Port ( CLK_IN : STD_LOGIC;
          btnCpuReset : in  STD_LOGIC;
 --         irq : in  STD_LOGIC;
 --         nmi : in  STD_LOGIC;
-         
+
          ----------------------------------------------------------------------
-         -- CIA1 ports for keyboard/joystick 
+         -- CIA1 ports for keyboard/joystick
          ----------------------------------------------------------------------
 --         porta_pins : inout  std_logic_vector(7 downto 0);
 --         portb_pins : inout  std_logic_vector(7 downto 0);
-         
+
          ----------------------------------------------------------------------
          -- VGA output
          ----------------------------------------------------------------------
@@ -66,13 +66,13 @@ entity container is
          eth_rxdv : in std_logic;
          eth_interrupt : in std_logic;
          eth_clock : out std_logic;
-         
+
          -------------------------------------------------------------------------
          -- Lines for the SDcard interface itself
          -------------------------------------------------------------------------
          sdReset : out std_logic := '0';  -- must be 0 to power SD controller (cs_bo)
          sdClock : out std_logic;       -- (sclk_o)
-         sdMOSI : out std_logic;      
+         sdMOSI : out std_logic;
          sdMISO : in  std_logic;
 
          ---------------------------------------------------------------------------
@@ -84,7 +84,7 @@ entity container is
          aclSCK : out std_logic;
          aclInt1 : in std_logic;
          aclInt2 : in std_logic;
-         
+
          micData : in std_logic;
          micClk : out std_logic;
          micLRSel : out std_logic;
@@ -103,30 +103,54 @@ entity container is
          ps2clk : in std_logic;
          ps2data : in std_logic;
 
+        --  ----------------------------------------------------------------------
+        --  -- PMODs for HyperRAM module
+        --  ----------------------------------------------------------------------
+        --  jalo : inout std_logic_vector(4 downto 1) := (others => 'Z');
+        --  jahi : inout std_logic_vector(10 downto 7) := (others => 'Z');
+        -- --  jblo : inout std_logic_vector(4 downto 1) := (others => 'Z');
+        -- --  jbhi : inout std_logic_vector(10 downto 7) := (others => 'Z');
+        --  jb : inout unsigned(7 downto 0) := (others => 'Z');
          ----------------------------------------------------------------------
-         -- PMOD for joystick interface
+         -- HyperRAM as expansion RAM
          ----------------------------------------------------------------------
-         jalo : in std_logic_vector(4 downto 1) := (others => 'Z');
-         jahi : in std_logic_vector(9 downto 7) := (others => '0');
+         hr_d : inout unsigned(7 downto 0) := (others => 'Z');
+         hr_rwds : inout std_logic := 'Z';
+         hr_reset : out std_logic := 'Z';
+         hr_clk_p : out std_logic := 'Z';
+         hr_clk_n : out std_logic := 'Z';
+         hr_cs0 : out std_logic := 'Z';
+         hr_cs1 : out std_logic := 'Z';
+         hr_cs2 : out std_logic := 'Z';
+         hr_cs3 : out std_logic := 'Z';
 
          ----------------------------------------------------------------------
-         -- PMODs for LCD screen and associated things during testing
+         -- PMODs for UART interfaces
          ----------------------------------------------------------------------
-         jblo : in std_logic_vector(4 downto 1) := (others => 'Z');
+         jblo : inout std_logic_vector(4 downto 1) := (others => 'Z');
+         ----------------------------------------------------------------------
+         -- PMOD for MKII keyboard interface
+         ----------------------------------------------------------------------
          jbhi : inout std_logic_vector(10 downto 7) := (others => 'Z');
+         ----------------------------------------------------------------------
+         -- PMOD for widget interface
+         ----------------------------------------------------------------------
          jclo : inout std_logic_vector(4 downto 1) := (others => 'Z');
          jchi : inout std_logic_vector(10 downto 7) := (others => 'Z');
          jdlo : inout std_logic_vector(4 downto 1) := (others => 'Z');
          jdhi : inout std_logic_vector(10 downto 7) := (others => 'Z');
-         jxadc : inout std_logic_vector(7 downto 0) := (others => 'Z');
-         
+        --  ----------------------------------------------------------------------
+        --  -- PMOD for joystick interface
+        --  ----------------------------------------------------------------------
+        --  jxadc : inout std_logic_vector(7 downto 0) := (others => 'Z');
+
          ----------------------------------------------------------------------
          -- Flash RAM for holding config
          ----------------------------------------------------------------------
 --         QspiSCK : out std_logic;
          QspiDB : inout unsigned(3 downto 0);
          QspiCSn : out std_logic;
-         
+
          ----------------------------------------------------------------------
          -- Cellular RAM interface for Slow RAM
          ----------------------------------------------------------------------
@@ -155,7 +179,7 @@ entity container is
 --         ddr2_dq        : inout std_logic_vector(15 downto 0);
 --         ddr2_dqs_p     : inout std_logic_vector(1 downto 0);
 --         ddr2_dqs_n     : inout std_logic_vector(1 downto 0);
-         
+
          ----------------------------------------------------------------------
          -- Debug interfaces on Nexys4 board
          ----------------------------------------------------------------------
@@ -165,7 +189,7 @@ entity container is
 
          UART_TXD : out std_logic;
          RsRx : in std_logic;
-         
+
          sseg_ca : out std_logic_vector(7 downto 0);
          sseg_an : out std_logic_vector(7 downto 0)
          );
@@ -179,18 +203,18 @@ architecture Behavioral of container is
            rst : in  STD_LOGIC;
            temp : out  STD_LOGIC_VECTOR (11 downto 0));
   end component;
-  
+
   signal irq : std_logic := '1';
   signal nmi : std_logic := '1';
   signal restore_key : std_logic := '1';
   signal reset_out : std_logic := '1';
   signal cpu_game : std_logic := '1';
   signal cpu_exrom : std_logic := '1';
-  
+
   signal buffer_vgared : unsigned(7 downto 0);
   signal buffer_vgagreen : unsigned(7 downto 0);
   signal buffer_vgablue : unsigned(7 downto 0);
-  
+
   signal ethclock : std_logic;
   signal ethclock_rotate : std_logic;
   signal cpuclock : std_logic;
@@ -210,9 +234,26 @@ architecture Behavioral of container is
   signal slow_access_wdata : unsigned(7 downto 0);
   signal slow_access_rdata : unsigned(7 downto 0);
 
+  signal slow_prefetched_address : unsigned(26 downto 0);
+  signal slow_prefetched_data : unsigned(7 downto 0);
+  signal slow_prefetched_request_toggle : std_logic;
+
   signal sector_buffer_mapped : std_logic;
 
-  
+  signal expansionram_read : std_logic;
+  signal expansionram_write : std_logic;
+  signal expansionram_rdata : unsigned(7 downto 0);
+  signal expansionram_wdata : unsigned(7 downto 0);
+  signal expansionram_address : unsigned(26 downto 0);
+  signal expansionram_data_ready_strobe : std_logic;
+  signal expansionram_busy : std_logic;
+
+  signal current_cache_line : cache_row_t := (others => (others => '0'));
+  signal current_cache_line_address : unsigned(26 downto 3) := (others => '0');
+  signal current_cache_line_valid : std_logic := '0';
+  signal expansionram_current_cache_line_next_toggle : std_logic := '0';
+
+
   signal vgaredignore : unsigned(3 downto 0);
   signal vgagreenignore : unsigned(3 downto 0);
   signal vgablueignore : unsigned(3 downto 0);
@@ -244,7 +285,7 @@ architecture Behavioral of container is
   signal cart_d : unsigned(7 downto 0) := (others => 'Z');
   signal cart_d_read : unsigned(7 downto 0) := (others => 'Z');
   signal cart_a : unsigned(15 downto 0) := (others => 'Z');
-  
+
   ----------------------------------------------------------------------
   -- CBM floppy serial port
   ----------------------------------------------------------------------
@@ -258,9 +299,9 @@ architecture Behavioral of container is
   signal iec_data_i : std_logic := '1';
   signal iec_clk_i : std_logic := '1';
   signal iec_srq_i : std_logic := '1';
-  signal iec_atn : std_logic := 'Z';  
+  signal iec_atn : std_logic := 'Z';
 
-  
+
   -- XXX We should read the real temperature and feed this to the DDR controller
   -- so that it can update timing whenever the temperature changes too much.
   signal fpga_temperature : std_logic_vector(11 downto 0) := (others => '0');
@@ -275,22 +316,131 @@ architecture Behavioral of container is
   signal lcd_vsync : std_logic;
   signal pal50_select : std_logic;
 
+  -- Assume MK-II keyboard on power on, for the reasons explained further down
+  -- in the file
+  signal mk1_connected : std_logic := '0';
+  signal mkii_counter : integer range 0 to 5000 := 5000;
+  signal xil_io1 : std_logic;
+  signal xil_io2 : std_logic;
+  signal xil_io3 : std_logic;
+  signal mk2_xil_io1 : std_logic;
+  signal mk2_xil_io2 : std_logic;
+  signal mk2_xil_io3 : std_logic;
+  signal mk2_io1 : std_logic;
+  signal mk2_io2 : std_logic;
+  signal mk2_io1_in : std_logic;
+  signal mk2_io2_in : std_logic;
+  signal mk2_io1_en : std_logic;
+  signal mk2_io2_en : std_logic;
+
+  signal kbd_matrix_col_idx : integer range 0 to 8 := 0;
+  signal kbd_matrix_col : std_logic_vector(7 downto 0) := (others => '1');
+  signal kbd_restore : std_logic;
+  signal kbd_capslock : std_logic;
+  signal kbd_disable : std_logic := '0';
+
   signal widget_matrix_col_idx : integer range 0 to 8 := 0;
-  signal widget_matrix_col : std_logic_vector(7 downto 0);
+  signal widget_matrix_col : std_logic_vector(7 downto 0) := (others => '1');
   signal widget_restore : std_logic;
   signal widget_capslock : std_logic;
   signal widget_joya : std_logic_vector(4 downto 0);
   signal widget_joyb : std_logic_vector(4 downto 0);
+  signal widget_disable : std_logic := '0';
+
+  signal com_matrix_col_idx : integer range 0 to 8 := 0;
+  signal com_matrix_col : std_logic_vector(7 downto 0);
+  signal com_restore : std_logic;
+  signal com_capslock : std_logic;
 
   signal qspi_clock : std_logic := '0';
   signal qspidb_oe : std_logic;
   signal qspidb_out : unsigned(3 downto 0);
   signal qspidb_in : unsigned(3 downto 0);
 
+  signal hyper_addr : unsigned(18 downto 3) := (others => '0');
+  signal hyper_request_toggle : std_logic := '0';
+  signal hyper_data : unsigned(7 downto 0) := x"00";
+  signal hyper_data_strobe : std_logic := '0';
+
+  -- signal hr_d : unsigned(7 downto 0) := (others => 'Z');
+
+  signal disco_led_en : std_logic := '0';
+  signal disco_led_val : unsigned(7 downto 0);
+  signal disco_led_id : unsigned(7 downto 0);
+
+  signal flopled0_drive : std_logic;
+  signal flopled2_drive : std_logic;
+  signal flopledsd_drive : std_logic;
+  signal flopmotor_drive : std_logic;
+
+  signal keyleft : std_logic := '0';
+  signal keyup : std_logic := '0';
+  -- On the R2 onwards, we don't use the "real" keyboard interface, but instead the
+  -- widget board interface, so just have these as dummy all-high place holders
+  signal column : std_logic_vector(8 downto 0) := (others => '1');
+  signal row : std_logic_vector(7 downto 0) := (others => '1');
+
   signal kbd_datestamp : unsigned(13 downto 0) := to_unsigned(0,14);
   signal kbd_commit : unsigned(31 downto 0) := to_unsigned(0,32);
 
+  signal fastkey : std_logic;
+
+  signal eth_load_enable : std_logic;
+
 begin
+
+  mk2: entity work.mk2_to_mk1
+  port map (
+    cpuclock => cpuclock,
+
+    mk2_xil_io1 => mk2_xil_io1,
+    mk2_xil_io2 => mk2_xil_io2,
+    mk2_xil_io3 => mk2_xil_io3,
+
+    mk2_io1_in => mk2_io1_in,
+    mk2_io1 => mk2_io1,
+    mk2_io1_en => mk2_io1_en,
+
+    mk2_io2_in => mk2_io2_in,
+    mk2_io2 => mk2_io2,
+    mk2_io2_en => mk2_io2_en
+
+    );
+
+  kbd0: entity work.mega65kbd_to_matrix
+    port map (
+      cpuclock => cpuclock,
+
+      disco_led_en => disco_led_en,
+      disco_led_id => disco_led_id,
+      disco_led_val => disco_led_val,
+
+      eth_load_enable => eth_load_enable,
+
+      powerled => '1',
+      flopled0 => flopled0_drive,
+      flopled2 => flopled2_drive,
+      flopledsd => flopledsd_drive,
+      flopmotor => flopmotor_drive,
+
+      kio8 => xil_io1,
+      kio9 => xil_io2,
+      kio10 => xil_io3,
+
+      kbd_datestamp => kbd_datestamp,
+      kbd_commit => kbd_commit,
+
+      fastkey_out => fastkey,
+
+      matrix_col => kbd_matrix_col,
+      matrix_col_idx => kbd_matrix_col_idx,
+      restore => kbd_restore,
+      capslock_out => kbd_capslock,
+      upkey => keyup,
+      leftkey => keyleft
+
+      );
+
 
 --STARTUPE2:STARTUPBlock--7Series
 
@@ -326,7 +476,7 @@ begin
              );
 -- End of STARTUPE2_inst instantiation
 
-    
+
   -- New clocking setup, using more optimised selection of multipliers
   -- and dividers, as well as the ability of some clock outputs to provide an
   -- inverted clock for free.
@@ -339,9 +489,9 @@ begin
                clock41   => cpuclock,   --   40.625 MHz
                clock50   => ethclock,   --   50     MHz
                clock81p  => pixelclock, --   81.25  MHz
-               clock163  => clock162,   -- 162.5    MHz
-               clock200  => clock200,   -- 200      MHz
-               clock325  => clock325    -- 325      MHz
+               clock163  => clock162,   --  162.5   MHz
+               clock200  => clock200,   --  200     MHz
+               clock325  => clock325    --  325     MHz
                );
 
   fpgatemp0: fpgatemp
@@ -354,21 +504,72 @@ begin
   widget0: entity work.widget_to_matrix port map(
     cpuclock => pixelclock,
 
-    pmod_clock => jblo(1),
-    pmod_start_of_sequence => jblo(2),
-    pmod_data_in(1 downto 0) => jblo(4 downto 3),
-    pmod_data_in(3 downto 2) => jbhi(8 downto 7),
-    pmod_data_out => jbhi(10 downto 9),
+    pmod_clock => jdlo(1),
+    pmod_start_of_sequence => jdlo(2),
+    pmod_data_in(1 downto 0) => jdlo(4 downto 3),
+    pmod_data_in(3 downto 2) => jdhi(8 downto 7),
+    pmod_data_out => jdhi(10 downto 9),
 
     matrix_col => widget_matrix_col,
     matrix_col_idx => widget_matrix_col_idx,
     restore => widget_restore,
     capslock_out => widget_capslock,
+    -- reset_out => reset_combined,
     joya => widget_joya,
     joyb => widget_joyb
-    );  
-  
+    );
+
+  hyperram0: entity work.hyperram
+    port map (
+      pixelclock => pixelclock,
+      clock163 => clock162,
+      clock325 => clock325,
+
+      -- XXX Debug by showing if expansion RAM unit is receiving requests or not
+--      request_counter => led,
+
+      viciv_addr => hyper_addr,
+      viciv_request_toggle => hyper_request_toggle,
+      viciv_data_out => hyper_data,
+      viciv_data_strobe => hyper_data_strobe,
+
+      -- reset => reset_out,
+      address => expansionram_address,
+      wdata => expansionram_wdata,
+      read_request => expansionram_read,
+      write_request => expansionram_write,
+      rdata => expansionram_rdata,
+      data_ready_strobe => expansionram_data_ready_strobe,
+      busy => expansionram_busy,
+
+      current_cache_line => current_cache_line,
+      current_cache_line_address => current_cache_line_address,
+      current_cache_line_valid => current_cache_line_valid,
+      expansionram_current_cache_line_next_toggle  => expansionram_current_cache_line_next_toggle,
+
+      hr_d => hr_d,
+      hr_rwds => hr_rwds,
+      hr_reset => hr_reset,
+      hr_clk_p => hr_clk_p,
+      hr_clk_n => hr_clk_n,
+
+      hr_cs0 => hr_cs0,
+      hr_cs1 => hr_cs1,
+      -- hr_cs2 => hr_cs2,
+      -- hr_cs3 => hr_cs3,
+
+      hr2_d => hr_d,
+      hr2_rwds => hr_rwds
+--      hr2_reset => hr2_reset,
+--      hr2_clk_p => hr2_clk_p
+--      hr_clk_n => hr_clk_n,
+--      hr_cs1 => hr2_cs0
+      );
+
   slow_devices0: entity work.slow_devices
+    generic map (
+      target => nexys4ddr_widget
+      )
     port map (
       cpuclock => cpuclock,
       pixelclock => pixelclock,
@@ -376,9 +577,9 @@ begin
       cpu_exrom => cpu_exrom,
       cpu_game => cpu_game,
       sector_buffer_mapped => sector_buffer_mapped,
-      
+
 --      qspidb => qspidb,
---      qspicsn => qspicsn,      
+--      qspicsn => qspicsn,
 --      qspisck => '1',
 
       slow_access_request_toggle => slow_access_request_toggle,
@@ -387,9 +588,26 @@ begin
       slow_access_address => slow_access_address,
       slow_access_wdata => slow_access_wdata,
       slow_access_rdata => slow_access_rdata,
-      
-      expansionram_data_ready_strobe => '1',
-      expansionram_busy => '1',
+
+      slow_prefetched_address => slow_prefetched_address,
+      slow_prefetched_data => slow_prefetched_data,
+      slow_prefetched_request_toggle => slow_prefetched_request_toggle,
+
+      ----------------------------------------------------------------------
+      -- Expansion RAM interface (upto 127MB)
+      ----------------------------------------------------------------------
+      expansionram_data_ready_strobe => expansionram_data_ready_strobe,
+      expansionram_busy => expansionram_busy,
+      expansionram_read => expansionram_read,
+      expansionram_write => expansionram_write,
+      expansionram_address => expansionram_address,
+      expansionram_rdata => expansionram_rdata,
+      expansionram_wdata => expansionram_wdata,
+
+      expansionram_current_cache_line => current_cache_line,
+      expansionram_current_cache_line_address => current_cache_line_address,
+      expansionram_current_cache_line_valid => current_cache_line_valid,
+      expansionram_current_cache_line_next_toggle  => expansionram_current_cache_line_next_toggle,
 
       ----------------------------------------------------------------------
       -- Expansion/cartridge port
@@ -401,11 +619,11 @@ begin
       cart_phi2 => cart_phi2,
       cart_dotclock => cart_dotclock,
       cart_reset => cart_reset,
-      
+
       cart_nmi => cart_nmi,
       cart_irq => cart_irq,
       cart_dma => cart_dma,
-      
+
       cart_exrom => cart_exrom,
       cart_ba => cart_ba,
       cart_rw => cart_rw,
@@ -414,223 +632,249 @@ begin
       cart_io1 => cart_io1,
       cart_game => cart_game,
       cart_io2 => cart_io2,
-      
+
       cart_d_in => cart_d_read,
       cart_d => cart_d,
       cart_a => cart_a
       );
 
   core0:
-    if true generate 
-  machine0: entity work.machine
-    generic map (cpu_frequency => 40500000,
-                 target => nexys4ddr_widget)
-    port map (
-      pixelclock      => pixelclock,
-      cpuclock        => cpuclock,
-      uartclock       => cpuclock, -- Match CPU clock
-      clock162 => clock162,
-      clock27 => clock27,
-      clock50mhz      => ethclock,
-      clock200  => clock200,
+    if true generate
+      machine0: entity work.machine
+        generic map (cpu_frequency => 40500000,
+                    target => nexys4ddr_widget)
+        port map (
+          pixelclock      => pixelclock,
+          cpuclock        => cpuclock,
+          uartclock       => cpuclock, -- Match CPU clock
+          clock162 => clock162,
+          clock27 => clock27,
+          clock50mhz      => ethclock,
+          clock200  => clock200,
 
-      btncpureset => btncpureset,
-      reset_out => reset_out,
-      irq => irq,
-      nmi => nmi,
-      restore_key => restore_key,
-      sector_buffer_mapped => sector_buffer_mapped,
+          btncpureset => btncpureset,
+          reset_out => reset_out,
+          irq => irq,
+          nmi => nmi,
+          restore_key => restore_key,
+          sector_buffer_mapped => sector_buffer_mapped,
 
-      qspi_clock => qspi_clock,
-      qspicsn => qspicsn,
-      qspidb => qspidb_out,
-      qspidb_in => qspidb_in,
-      qspidb_oe => qspidb_oe,
-     
-      pal50_select_out => pal50_select,
-      
-      -- Wire up a dummy caps_lock key on switch 8
-      caps_lock_key => sw(8),
+          qspi_clock => qspi_clock,
+          qspicsn => qspicsn,
+          qspidb => qspidb_out,
+          qspidb_in => qspidb_in,
+          qspidb_oe => qspidb_oe,
 
-      -- fa_fire => '1',
-      -- fa_up =>  '1',
-	  -- fa_left => '1',
-      -- fa_down => '1',
-      -- fa_right => '1',
+          hyper_addr => hyper_addr,
+          hyper_request_toggle => hyper_request_toggle,
+          hyper_data => hyper_data,
+          hyper_data_strobe => hyper_data_strobe,
 
-	  -- Joystick port via PMOD
-      fa_fire => jahi(9),
-      fa_up => jalo(1),     
-      fa_left => jalo(2),
-      fa_down => jahi(7),
-      fa_right => jahi(8),
+          kbd_datestamp => kbd_datestamp,
+          kbd_commit => kbd_commit,
 
-      fb_fire => '1',
-      fb_up => '1',
-      fb_left => '1',
-      fb_down => '1',
-      fb_right => '1',
+          pal50_select_out => pal50_select,
 
-      fa_potx => '0',
-      fa_poty => '0',
-      fb_potx => '0',
-      fb_poty => '0',
+          -- Wire up a dummy caps_lock key on switch 8
+          caps_lock_key => sw(8),
 
-      f_index => '1',
-      f_track0 => '1',
-      f_writeprotect => '1',
-      f_rdata => '1',
-      f_diskchanged => '1',
-      
-      ----------------------------------------------------------------------
-      -- CBM floppy  std_logic_vectorerial port
-      ----------------------------------------------------------------------
-      iec_clk_en => iec_clk_en,
-      iec_data_en => iec_data_en,
-      iec_srq_en => iec_srq_en,
-      iec_data_o => iec_data_o,
-      iec_reset => iec_reset,
-      iec_clk_o => iec_clk_o,
-      iec_atn_o => iec_atn,
-      iec_data_external => iec_data_i,
-      iec_clk_external => iec_clk_i,
-      iec_srq_external => iec_srq_i,
-      iec_bus_active => '0', -- No IEC port on this target
-      
-      no_hyppo => '0',
-      
-      vsync           => vsync,
-      vga_hsync           => hsync,
-      lcd_vsync => lcd_vsync,
-      lcd_hsync => lcd_hsync,
+        --   fa_fire => '1',
+        --   fa_up =>   '1',
+        --   fa_left => '1',
+        --   fa_down => '1',
+        --   fa_right =>'1',
 
-      vgared(7 downto 0)          => buffer_vgared,
-      vgagreen(7 downto 0)        => buffer_vgagreen,
-      vgablue(7 downto 0)         => buffer_vgablue,
+          fa_fire => widget_joya(4),
+          fa_up =>   widget_joya(0),
+          fa_left => widget_joya(1),
+          fa_down => widget_joya(2),
+          fa_right =>widget_joya(3),
 
-      porta_pins => porta_pins,
-      portb_pins => portb_pins,
-      keyleft => '0',
-      keyup => '0',
-      
-      ---------------------------------------------------------------------------
-      -- IO lines to the ethernet controller
-      ---------------------------------------------------------------------------
-      eth_mdio => eth_mdio,
-      eth_mdc => eth_mdc,
-      eth_reset => eth_reset,
-      eth_rxd => eth_rxd,
-      eth_txd => eth_txd,
-      eth_txen => eth_txen,
-      eth_rxer => eth_rxer,
-      eth_rxdv => eth_rxdv,
-      eth_interrupt => eth_interrupt,
-      
-      -------------------------------------------------------------------------
-      -- Lines for the SDcard interface itself
-      -------------------------------------------------------------------------
-      cs_bo => sdReset,
-      sclk_o => sdClock,
-      mosi_o => sdMOSI,
-      miso_i => sdMISO,
-      miso2_i => '1',
+        -- Joystick port via PMOD
+        --   fa_fire => jchi(9),
+        --   fa_up => jclo(1),
+        --   fa_left => jclo(2),
+        --   fa_down => jchi(7),
+        --   fa_right => jchi(8),
 
-      aclMISO => aclMISO,
-      aclMOSI => aclMOSI,
-      aclSS => aclSS,
-      aclSCK => aclSCK,
-      aclInt1 => aclInt1,
-      aclInt2 => aclInt2,
-      
-      micData0 => micData,
-      micData1 => '0', -- This board has only one microphone
-      micClk => micClk,
-      micLRSel => micLRSel,
+          fb_fire => '1',
+          fb_up =>   '1',
+          fb_left => '1',
+          fb_down => '1',
+          fb_right =>'1',
 
-      ampPWM_l => ampPWM_internal,
-      ampPWM_r => led(14),
-      ampSD => ampSD,
-      
-      tmpSDA => tmpSDA,
-      tmpSCL => tmpSCL,
-      tmpInt => tmpInt,
-      tmpCT => tmpCT,
+          fa_potx => '0',
+          fa_poty => '0',
+          fb_potx => '0',
+          fb_poty => '0',
 
-      touchSDA => jdlo(2),
-      touchSCL => jdlo(1),
-      lcdpwm => jdlo(3),
+          f_index => '1',
+          f_track0 => '1',
+          f_writeprotect => '1',
+          f_rdata => '1',
+          f_diskchanged => '1',
 
-      -- Add second I2C bus we can connect to external things for testing.
-      i2c1sda => jdlo(4),
-      i2c1scl => jchi(7),
+          ----------------------------------------------------------------------
+          -- CBM floppy  std_logic_vectorerial port
+          ----------------------------------------------------------------------
+          iec_clk_en => iec_clk_en,
+          iec_data_en => iec_data_en,
+          iec_srq_en => iec_srq_en,
+          iec_data_o => iec_data_o,
+          iec_reset => iec_reset,
+          iec_clk_o => iec_clk_o,
+          iec_atn_o => iec_atn,
+          iec_data_external => iec_data_i,
+          iec_clk_external => iec_clk_i,
+          iec_srq_external => iec_srq_i,
+          iec_bus_active => '0', -- No IEC port on this target
 
-      kbd_datestamp => kbd_datestamp,
-      kbd_commit => kbd_commit,
-      
-      -- This is for modem as PCM master:
-      pcm_modem_clk_in => jdhi(7),
-      pcm_modem_sync_in => jdhi(8),
-      -- This is for modem as PCM slave:
-      -- (note that the EC25AU firmware we have doesn't work properly as a PCM
-      -- slave).
-      -- pcm_modem_clk => jdhi(7),
-      -- pcm_modem_sync => jdhi(8),
-      
-      pcm_modem1_data_out => jdhi(9),
-      pcm_modem1_data_in => jdhi(10),
-      
-      ps2data =>      ps2data,
-      ps2clock =>     ps2clk,
+          no_hyppo => '0',
 
-      widget_matrix_col_idx => widget_matrix_col_idx,
-      widget_matrix_col => widget_matrix_col,
-      widget_restore => widget_restore,
-      widget_capslock => widget_capslock,
-      widget_joya => widget_joya,
-      widget_joyb => widget_joyb,      
-      
-      uart_rx => jclo(1),
-      uart_tx => jclo(2),
+          vsync           => vsync,
+          vga_hsync           => hsync,
+          lcd_vsync => lcd_vsync,
+          lcd_hsync => lcd_hsync,
 
---      buffereduart_rx => jclo(3),
---      buffereduart_tx => jclo(4),
---      buffereduart2_rx => jchi(9),
---      buffereduart2_tx => jchi(10),
-      buffereduart_ringindicate => (others => '0'),
-      
-      slow_access_request_toggle => slow_access_request_toggle,
-      slow_access_ready_toggle => slow_access_ready_toggle,
-      slow_access_address => slow_access_address,
-      slow_access_write => slow_access_write,
-      slow_access_wdata => slow_access_wdata,
-      slow_access_rdata => slow_access_rdata,
---      cpu_exrom => cpu_exrom,      
---      cpu_game => cpu_game,      
-      -- enable/disable cartridge with sw(8)
-      cpu_exrom => '1',
-      cpu_game => '1',
-      cart_access_count => x"00",
+          vgared(7 downto 0)          => buffer_vgared,
+          vgagreen(7 downto 0)        => buffer_vgagreen,
+          vgablue(7 downto 0)         => buffer_vgablue,
 
-      fpga_temperature => fpga_temperature,
+          porta_pins => column(7 downto 0),
+          portb_pins => row(7 downto 0),
+          keyboard_column8 => column(8),
+          keyleft => keyleft,
+          keyup => keyup,
 
-      led(12 downto 0) => led(12 downto 0),
-      led(15 downto 13) => dummy,
-      dipsw(0) => '0',
-      dipsw(1) => sw(11), -- switch 11 turns on ethernet remote control 
-      dipsw(2) => '0',
-      dipsw(3) => '0',
-      dipsw(4) => '0',
-      sw => sw,
-      btn => btn,
+          disco_led_en => disco_led_en,
+          disco_led_id => disco_led_id,
+          disco_led_val => disco_led_val,
 
-      UART_TXD => UART_TXD,
-      RsRx => RsRx,
-      
-      sseg_ca => sseg_ca,
-      sseg_an => sseg_an
-      );
-  end generate core0;
-  
+          flopled0 => flopled0_drive,
+          flopled2 => flopled2_drive,
+          flopledsd => flopledsd_drive,
+          flopmotor => flopmotor_drive,
+
+          ---------------------------------------------------------------------------
+          -- IO lines to the ethernet controller
+          ---------------------------------------------------------------------------
+          eth_mdio => eth_mdio,
+          eth_mdc => eth_mdc,
+          eth_reset => eth_reset,
+          eth_rxd => eth_rxd,
+          eth_txd => eth_txd,
+          eth_txen => eth_txen,
+          eth_rxer => eth_rxer,
+          eth_rxdv => eth_rxdv,
+          eth_interrupt => eth_interrupt,
+
+          -------------------------------------------------------------------------
+          -- Lines for the SDcard interface itself
+          -------------------------------------------------------------------------
+          cs_bo => sdReset,
+          sclk_o => sdClock,
+          mosi_o => sdMOSI,
+          miso_i => sdMISO,
+          miso2_i => '1',
+
+          aclMISO => aclMISO,
+          aclMOSI => aclMOSI,
+          aclSS => aclSS,
+          aclSCK => aclSCK,
+          aclInt1 => aclInt1,
+          aclInt2 => aclInt2,
+
+          micData0 => micData,
+          micData1 => '0', -- This board has only one microphone
+          micClk => micClk,
+          micLRSel => micLRSel,
+
+          ampPWM_l => ampPWM_internal,
+          ampPWM_r => led(14),
+          ampSD => ampSD,
+
+          tmpSDA => tmpSDA,
+          tmpSCL => tmpSCL,
+          tmpInt => tmpInt,
+          tmpCT => tmpCT,
+
+          touchSDA => jblo(4),
+          touchSCL => jblo(3),
+          lcdpwm => jbhi(10),
+
+          -- Add second I2C bus we can connect to external things for testing.
+          -- i2c1sda => jdlo(4),
+          -- i2c1scl => jchi(7),
+
+          -- This is for modem as PCM master:
+          pcm_modem_clk_in => jchi(7),
+          pcm_modem_sync_in => jchi(8),
+          -- This is for modem as PCM slave:
+          -- (note that the EC25AU firmware we have doesn't work properly as a PCM
+          -- slave).
+          -- pcm_modem_clk => jchi(7),
+          -- pcm_modem_sync => jchi(8),
+
+          pcm_modem1_data_out => jchi(9),
+          pcm_modem1_data_in => jchi(10),
+
+          ps2data =>      ps2data,
+          ps2clock =>     ps2clk,
+
+          widget_matrix_col_idx => com_matrix_col_idx,
+          widget_matrix_col => com_matrix_col,
+          widget_restore => com_restore,
+          widget_capslock => com_capslock,
+          widget_joya => widget_joya,
+          widget_joyb => widget_joyb,
+
+          uart_rx => jblo(1),
+          uart_tx => jblo(2),
+
+    --      buffereduart_rx => jblo(3),
+    --      buffereduart_tx => jblo(4),
+    --      buffereduart2_rx => jbhi(9),
+    --      buffereduart2_tx => jbhi(10),
+          buffereduart_ringindicate => (others => '0'),
+
+          slow_access_request_toggle => slow_access_request_toggle,
+          slow_access_ready_toggle => slow_access_ready_toggle,
+          slow_access_address => slow_access_address,
+          slow_access_write => slow_access_write,
+          slow_access_wdata => slow_access_wdata,
+          slow_access_rdata => slow_access_rdata,
+
+          slow_prefetched_address => slow_prefetched_address,
+          slow_prefetched_data => slow_prefetched_data,
+          slow_prefetched_request_toggle => slow_prefetched_request_toggle,
+
+    --      cpu_exrom => cpu_exrom,
+    --      cpu_game => cpu_game,
+          -- enable/disable cartridge with sw(8)
+          cpu_exrom => '1',
+          cpu_game => '1',
+          cart_access_count => x"00",
+
+          fpga_temperature => fpga_temperature,
+
+          led(12 downto 0) => led(12 downto 0),
+          led(15 downto 13) => dummy,
+          dipsw(0) => '0',
+          dipsw(1) => sw(11), -- switch 11 turns on ethernet remote control
+          dipsw(2) => '0',
+          dipsw(3) => '0',
+          dipsw(4) => '0',
+          sw => sw,
+          btn => btn,
+
+          UART_TXD => UART_TXD,
+          RsRx => RsRx,
+
+          sseg_ca => sseg_ca,
+          sseg_an => sseg_an
+          );
+    end generate;
+
   -- Hardware buttons for triggering IRQ & NMI
   irq <= not btn(0);
   nmi <= not btn(4);
@@ -643,11 +887,27 @@ begin
 
   qspidb <= qspidb_out when qspidb_oe='1' else "ZZZZ";
   qspidb_in <= qspidb;
-  
+
+  -- jalo(1) <= '1';
+  -- jahi(7) <= '1';
+  -- hr_cs0 <= '1';
+  -- hr_cs1 <= '1';
+  -- hr_cs2 <= '1';
+  -- hr_cs3 <= '1';
+
+  widget_matrix_col_idx <= com_matrix_col_idx;
+  kbd_matrix_col_idx <= com_matrix_col_idx;
+  com_matrix_col <=
+                    "11111111"
+                    and (widget_matrix_col or (7 downto 0 => widget_disable))
+                    and (kbd_matrix_col or (7 downto 0 => kbd_disable));
+  com_restore <= '1' and (kbd_restore or kbd_disable) and (widget_restore or widget_disable);
+  com_capslock <= '1'and (kbd_capslock or kbd_disable) and (widget_capslock or widget_disable);
+
   process (cpuclock,pixelclock,cpuclock,pal50_select)
   begin
-    if rising_edge(pixelclock) then      
-      
+    if rising_edge(pixelclock) then
+
       if sw(7)='0' then
         -- VGA direct output
         vgared <= buffer_vgared(7 downto 4);
@@ -664,8 +924,8 @@ begin
     if rising_edge(cpuclock) then
 
       -- No physical keyboard
-      portb_pins <= (others => '1');
-      
+      -- portb_pins <= (others => '1');
+
       -- Debug audio output
       if sw(7) = '0' then
         ampPWM <= ampPWM_internal;
@@ -692,9 +952,67 @@ begin
           end if;
 --          qspi_clock <= not qspi_clock_int;
 --          qspi_clock_int <= not qspi_clock_int;
-          
+
         end if;
       end if;
+
+      if widget_matrix_col = x"FF" then
+        widget_disable <= '1';
+      elsif kbd_matrix_col = x"FF" then
+        kbd_disable <= '1';
+      end if;
+
+      -- Detect MK-I keyboard by looking for KIO10 going high, as MK-II keyboard
+      -- holds this line forever low.  As MK-I will start with KIO10 high, we can
+      -- assume MK-II keyboard, and correct our decision in 1 clock tick if it was
+      -- wrong.  Doing it the other way around would cause fake key presses during
+      -- the 5000 cycles while we wait to decide it really is a MK-II keyboard.
+      led(13) <= mk1_connected;
+      if to_X01(jbhi(9)) = '1' then
+        mkii_counter <= 0;
+        mk1_connected <= '1';
+        if mk1_connected='0' then
+          report "Switching to MK-I keyboard protocol";
+        end if;
+      else
+        if mkii_counter < 5000 then
+          mkii_counter <= mkii_counter + 1;
+        else
+          mk1_connected <= '0';
+          if mk1_connected='1' then
+            report "Switching to MK-II keyboard protocol";
+          end if;
+        end if;
+      end if;
+    end if;
+
+    if mk1_connected='1' then
+      -- Connect MK-I keyboard to keyboard decoder
+      jbhi(7) <= xil_io1;
+      jbhi(8) <= xil_io2;
+      xil_io3 <= jbhi(9);
+    else
+      -- MK-II keyboard connected
+      -- Make tri-state link from keyboard connector to MK-II controller
+      mk2_io1_in <= jbhi(7);
+      if mk2_io1_en='1' then
+        jbhi(7) <= mk2_io1;
+      else
+        jbhi(7) <= 'Z';
+      end if;
+      mk2_io2_in <= jbhi(8);
+      if mk2_io2_en='1' then
+--        report "io2 drive : k_io2 <= " & std_logic'image(mk2_io2);
+        jbhi(8) <= mk2_io2;
+      else
+--        report "io2 Z";
+        jbhi(8) <= 'Z';
+      end if;
+
+      -- Connect Xilinx MK-I interface to MK-II controller
+      mk2_xil_io1 <= xil_io1;
+      mk2_xil_io2 <= xil_io2;
+      xil_io3 <= mk2_xil_io3;
     end if;
   end process;
 

--- a/src/vhdl/nexys4ddr-widget.xdc
+++ b/src/vhdl/nexys4ddr-widget.xdc
@@ -97,34 +97,82 @@ set_property -dict {PACKAGE_PIN M17 IOSTANDARD LVCMOS33} [get_ports {btn[2]}]
 set_property -dict {PACKAGE_PIN P17 IOSTANDARD LVCMOS33} [get_ports {btn[3]}]
 set_property -dict {PACKAGE_PIN P18 IOSTANDARD LVCMOS33} [get_ports {btn[1]}]
 
-##Pmod Header JA
-set_property -dict {PACKAGE_PIN C17 IOSTANDARD LVCMOS33} [get_ports {jalo[1]}]
-set_property -dict {PACKAGE_PIN D18 IOSTANDARD LVCMOS33} [get_ports {jalo[2]}]
-set_property -dict {PACKAGE_PIN E18 IOSTANDARD LVCMOS33} [get_ports {jalo[3]}]
-set_property -dict {PACKAGE_PIN G17 IOSTANDARD LVCMOS33} [get_ports {jalo[4]}]
-set_property -dict {PACKAGE_PIN D17 IOSTANDARD LVCMOS33} [get_ports {jahi[7]}]
-set_property -dict {PACKAGE_PIN E17 IOSTANDARD LVCMOS33} [get_ports {jahi[8]}]
-set_property -dict {PACKAGE_PIN F18 IOSTANDARD LVCMOS33} [get_ports {jahi[9]}]
-set_property -dict {PACKAGE_PIN G18 IOSTANDARD LVCMOS33} [get_ports {jahi[10]}]
+
+## Hyper RAM on PMOD Header JXADC and JA
+set_property -dict {PACKAGE_PIN A15 IOSTANDARD LVCMOS33 PULLUP FALSE} [get_ports {hr_cs0}]
+set_property -dict {PACKAGE_PIN A16 IOSTANDARD LVCMOS33 PULLUP FALSE} [get_ports {hr_cs1}]
+set_property -dict {PACKAGE_PIN A13 IOSTANDARD LVCMOS33 PULLUP FALSE} [get_ports {hr_cs2}]
+set_property -dict {PACKAGE_PIN A14 IOSTANDARD LVCMOS33 PULLUP FALSE} [get_ports {hr_cs3}]
+set_property -dict {PACKAGE_PIN B17 IOSTANDARD LVCMOS33 PULLUP FALSE} [get_ports {hr_reset}]
+set_property -dict {PACKAGE_PIN A18 IOSTANDARD LVCMOS33 PULLUP FALSE SLEW FAST DRIVE 16} [get_ports {hr_rwds}]
+set_property -dict {PACKAGE_PIN B16 IOSTANDARD LVCMOS33 PULLUP FALSE SLEW FAST DRIVE 16} [get_ports {hr_clk_p}]
+set_property -dict {PACKAGE_PIN B18 IOSTANDARD LVCMOS33 PULLUP FALSE SLEW FAST DRIVE 16} [get_ports {hr_clk_n}]
+set_property -dict {PACKAGE_PIN C17 IOSTANDARD LVCMOS33 PULLUP FALSE SLEW FAST DRIVE 16} [get_ports {hr_d[0]}]
+set_property -dict {PACKAGE_PIN D18 IOSTANDARD LVCMOS33 PULLUP FALSE SLEW FAST DRIVE 16} [get_ports {hr_d[1]}]
+set_property -dict {PACKAGE_PIN E18 IOSTANDARD LVCMOS33 PULLUP FALSE SLEW FAST DRIVE 16} [get_ports {hr_d[2]}]
+set_property -dict {PACKAGE_PIN G17 IOSTANDARD LVCMOS33 PULLUP FALSE SLEW FAST DRIVE 16} [get_ports {hr_d[3]}]
+set_property -dict {PACKAGE_PIN G18 IOSTANDARD LVCMOS33 PULLUP FALSE SLEW FAST DRIVE 16} [get_ports {hr_d[4]}]
+set_property -dict {PACKAGE_PIN F18 IOSTANDARD LVCMOS33 PULLUP FALSE SLEW FAST DRIVE 16} [get_ports {hr_d[5]}]
+set_property -dict {PACKAGE_PIN E17 IOSTANDARD LVCMOS33 PULLUP FALSE SLEW FAST DRIVE 16} [get_ports {hr_d[6]}]
+set_property -dict {PACKAGE_PIN D17 IOSTANDARD LVCMOS33 PULLUP FALSE SLEW FAST DRIVE 16} [get_ports {hr_d[7]}]
+# Place HyperRAM close to I/O pins
+create_pblock pblock_hyperram
+add_cells_to_pblock pblock_hyperram [get_cells [list hyperram0]]
+resize_pblock pblock_hyperram -add {SLICE_X0Y100:SLICE_X31Y149}
+
+# 80 MHz Hyperram bus
+set hbus_freq_ns   12
+# Set allowable clock drift
+set dqs_in_min_dly -0.5
+set dqs_in_max_dly  0.5
+
+# Set 6ns max delay to/from various HyperRAM pins
+# (But add 17ns extra, because of weird ways Vivado calculates the apparent latency)
+set hr0_dq_ports    [get_ports hr_d[*]]
+set_max_delay -from [get_clocks clock163] -to ${hr0_dq_ports} 23
+set_max_delay -to [get_clocks clock163] -from ${hr0_dq_ports} 23
+set_max_delay -from [get_clocks clock163] -to hr_rwds 23
+set_max_delay -to [get_clocks clock163] -from hr_rwds 23
+# set hr2_dq_ports    [get_ports hr2_d[*]]
+# set_max_delay -from [get_clocks clock163] -to ${hr2_dq_ports} 23
+# set_max_delay -to [get_clocks clock163] -from ${hr2_dq_ports} 23
+# set_max_delay -from [get_clocks clock163] -to hr2_rwds 23
+# set_max_delay -to [get_clocks clock163] -from hr2_rwds 23
+
+
+# ##Pmod Header JA
+# set_property -dict {PACKAGE_PIN C17 IOSTANDARD LVCMOS33} [get_ports {jalo[1]}]
+# set_property -dict {PACKAGE_PIN D18 IOSTANDARD LVCMOS33} [get_ports {jalo[2]}]
+# set_property -dict {PACKAGE_PIN E18 IOSTANDARD LVCMOS33} [get_ports {jalo[3]}]
+# set_property -dict {PACKAGE_PIN G17 IOSTANDARD LVCMOS33} [get_ports {jalo[4]}]
+# set_property -dict {PACKAGE_PIN D17 IOSTANDARD LVCMOS33} [get_ports {jahi[7]}]
+# set_property -dict {PACKAGE_PIN E17 IOSTANDARD LVCMOS33} [get_ports {jahi[8]}]
+# set_property -dict {PACKAGE_PIN F18 IOSTANDARD LVCMOS33} [get_ports {jahi[9]}]
+# set_property -dict {PACKAGE_PIN G18 IOSTANDARD LVCMOS33} [get_ports {jahi[10]}]
 
 ##Pmod Header JB
 set_property -dict {PACKAGE_PIN D14 IOSTANDARD LVCMOS33} [get_ports {jblo[1]}]
 set_property -dict {PACKAGE_PIN F16 IOSTANDARD LVCMOS33} [get_ports {jblo[2]}]
 set_property -dict {PACKAGE_PIN G16 IOSTANDARD LVCMOS33} [get_ports {jblo[3]}]
 set_property -dict {PACKAGE_PIN H14 IOSTANDARD LVCMOS33} [get_ports {jblo[4]}]
-set_property PACKAGE_PIN E16 [get_ports {jbhi[7]}]
-set_property IOSTANDARD LVCMOS33 [get_ports {jbhi[7]}]
+
+# MKII Keyboard connected to jbhi
+set_property -dict {PACKAGE_PIN E16 IOSTANDARD LVCMOS33} [get_ports {jbhi[7]}]
 set_property -dict {PACKAGE_PIN F13 IOSTANDARD LVCMOS33} [get_ports {jbhi[8]}]
 set_property -dict {PACKAGE_PIN G13 IOSTANDARD LVCMOS33} [get_ports {jbhi[9]}]
 set_property -dict {PACKAGE_PIN H16 IOSTANDARD LVCMOS33} [get_ports {jbhi[10]}]
+# Place Keyboard close to I/O pins
+create_pblock pblock_kbd0
+add_cells_to_pblock pblock_kbd0 [get_cells [list kbd0 mk2]]
+resize_pblock pblock_kbd0 -add {SLICE_X0Y100:SLICE_X31Y149}
 
 ##Pmod Header JC
 set_property -dict {PACKAGE_PIN K1 IOSTANDARD LVCMOS33} [get_ports {jclo[1]}]
 set_property -dict {PACKAGE_PIN F6 IOSTANDARD LVCMOS33} [get_ports {jclo[2]}]
 set_property -dict {PACKAGE_PIN J2 IOSTANDARD LVCMOS33} [get_ports {jclo[3]}]
 set_property -dict {PACKAGE_PIN G6 IOSTANDARD LVCMOS33} [get_ports {jclo[4]}]
-set_property -dict { PACKAGE_PIN E7 IOSTANDARD LVCMOS33 } [get_ports {jchi[7]}]
-set_property -dict { PACKAGE_PIN J3 IOSTANDARD LVCMOS33 } [get_ports {jchi[8]}]
+set_property -dict {PACKAGE_PIN E7 IOSTANDARD LVCMOS33} [get_ports {jchi[7]}]
+set_property -dict {PACKAGE_PIN J3 IOSTANDARD LVCMOS33} [get_ports {jchi[8]}]
 set_property -dict {PACKAGE_PIN J4 IOSTANDARD LVCMOS33} [get_ports {jchi[9]}]
 set_property -dict {PACKAGE_PIN E6 IOSTANDARD LVCMOS33} [get_ports {jchi[10]}]
 
@@ -139,7 +187,15 @@ set_property -dict {PACKAGE_PIN G4 IOSTANDARD LVCMOS33} [get_ports {jdhi[8]}]
 set_property -dict {PACKAGE_PIN G2 IOSTANDARD LVCMOS33} [get_ports {jdhi[9]}]
 set_property -dict {PACKAGE_PIN F3 IOSTANDARD LVCMOS33} [get_ports {jdhi[10]}]
 
-##Pmod Header JXADC
+# ##Pmod Header JXADC
+# set_property -dict {PACKAGE_PIN A13 IOSTANDARD LVCMOS33} [get_ports {jxadc[0]}]
+# set_property -dict {PACKAGE_PIN A15 IOSTANDARD LVCMOS33} [get_ports {jxadc[1]}]
+# set_property -dict {PACKAGE_PIN B16 IOSTANDARD LVCMOS33} [get_ports {jxadc[2]}]
+# set_property -dict {PACKAGE_PIN B18 IOSTANDARD LVCMOS33} [get_ports {jxadc[3]}]
+# set_property -dict {PACKAGE_PIN A14 IOSTANDARD LVCMOS33} [get_ports {jxadc[4]}]
+# set_property -dict {PACKAGE_PIN A16 IOSTANDARD LVCMOS33} [get_ports {jxadc[5]}]
+# set_property -dict {PACKAGE_PIN B17 IOSTANDARD LVCMOS33} [get_ports {jxadc[6]}]
+# set_property -dict {PACKAGE_PIN A18 IOSTANDARD LVCMOS33} [get_ports {jxadc[7]}]
 
 ##VGA Connector
 set_property -dict {PACKAGE_PIN A3 IOSTANDARD LVCMOS33} [get_ports {vgared[0]}]
@@ -197,12 +253,8 @@ set_property -dict {PACKAGE_PIN D4 IOSTANDARD LVCMOS33} [get_ports UART_TXD]
 #set_property -dict { PACKAGE_PIN E5 IOSTANDARD LVCMOS33 } [get_ports RsRts]
 
 ##USB HID (PS/2)
-set_property PACKAGE_PIN F4 [get_ports ps2clk]
-set_property IOSTANDARD LVCMOS33 [get_ports ps2clk]
-set_property PULLUP true [get_ports ps2clk]
-set_property PACKAGE_PIN B2 [get_ports ps2data]
-set_property IOSTANDARD LVCMOS33 [get_ports ps2data]
-set_property PULLUP true [get_ports ps2data]
+set_property -dict {PACKAGE_PIN F4 IOSTANDARD LVCMOS33 PULLUP true} [get_ports ps2clk]
+set_property -dict {PACKAGE_PIN B2 IOSTANDARD LVCMOS33 PULLUP true} [get_ports ps2data]
 
 ##SMSC Ethernet PHY
 set_property -dict {PACKAGE_PIN C9 IOSTANDARD LVCMOS33} [get_ports eth_mdc]
@@ -220,16 +272,49 @@ set_property -dict {PACKAGE_PIN D5 IOSTANDARD LVCMOS33} [get_ports eth_clock]
 set_property -dict {PACKAGE_PIN B8 IOSTANDARD LVCMOS33} [get_ports eth_interrupt]
 
 ##Quad SPI Flash
- #set_property  -dict { PACKAGE_PIN E9  IOSTANDARD LVCMOS33 } [get_ports {QspiSCK}]
-set_property -dict {PACKAGE_PIN K17 IOSTANDARD LVCMOS33} [get_ports {QspiDB[0]}]
-set_property -dict {PACKAGE_PIN K18 IOSTANDARD LVCMOS33} [get_ports {QspiDB[1]}]
-set_property -dict {PACKAGE_PIN L14 IOSTANDARD LVCMOS33} [get_ports {QspiDB[2]}]
-set_property -dict {PACKAGE_PIN M14 IOSTANDARD LVCMOS33} [get_ports {QspiDB[3]}]
-set_property -dict {PACKAGE_PIN L13 IOSTANDARD LVCMOS33} [get_ports QspiCSn]
-set_property PULLUP true [get_ports {qspidb[0]}]
-set_property PULLUP true [get_ports {qspidb[1]}]
-set_property PULLUP true [get_ports {qspidb[2]}]
-set_property PULLUP true [get_ports {qspidb[3]}]
+# set_property  -dict { PACKAGE_PIN E9  IOSTANDARD LVCMOS33 } [get_ports {QspiSCK}]
+set_property -dict {PACKAGE_PIN K17 IOSTANDARD LVCMOS33 PULLUP true} [get_ports {QspiDB[0]}]
+set_property -dict {PACKAGE_PIN K18 IOSTANDARD LVCMOS33 PULLUP true} [get_ports {QspiDB[1]}]
+set_property -dict {PACKAGE_PIN L14 IOSTANDARD LVCMOS33 PULLUP true} [get_ports {QspiDB[2]}]
+set_property -dict {PACKAGE_PIN M14 IOSTANDARD LVCMOS33 PULLUP true} [get_ports {QspiDB[3]}]
+set_property -dict {PACKAGE_PIN L13 IOSTANDARD LVCMOS33 PULLUP true} [get_ports QspiCSn]
+# Place QSPI controller close to I/O pins
+create_pblock pblock_qspi
+add_cells_to_pblock pblock_qspi [get_cells [list core0.machine0/iomapper0/sdcard0/QspiCSn_i_1
+                                                 core0.machine0/iomapper0/sdcard0/QspiCSn_i_10
+                                                 core0.machine0/iomapper0/sdcard0/QspiCSn_i_11
+                                                 core0.machine0/iomapper0/sdcard0/QspiCSn_i_2
+                                                 core0.machine0/iomapper0/sdcard0/QspiCSn_i_3
+                                                 core0.machine0/iomapper0/sdcard0/QspiCSn_i_4
+                                                 core0.machine0/iomapper0/sdcard0/QspiCSn_i_5
+                                                 core0.machine0/iomapper0/sdcard0/QspiCSn_i_6
+                                                 core0.machine0/iomapper0/sdcard0/QspiCSn_i_7
+                                                 core0.machine0/iomapper0/sdcard0/QspiCSn_i_8
+                                                 core0.machine0/iomapper0/sdcard0/QspiCSn_i_9
+                                                 core0.machine0/iomapper0/sdcard0/QspiCSn_reg
+                                                 core0.machine0/iomapper0/sdcard0/QspiDB[0]_i_10
+                                                 core0.machine0/iomapper0/sdcard0/QspiDB[0]_i_11
+                                                 core0.machine0/iomapper0/sdcard0/QspiDB[0]_i_12
+                                                 core0.machine0/iomapper0/sdcard0/QspiDB[0]_i_13
+                                                 core0.machine0/iomapper0/sdcard0/QspiDB[0]_i_14
+                                                 core0.machine0/iomapper0/sdcard0/QspiDB[0]_i_3
+                                                 core0.machine0/iomapper0/sdcard0/QspiDB[0]_i_4
+                                                 core0.machine0/iomapper0/sdcard0/QspiDB[0]_i_5
+                                                 core0.machine0/iomapper0/sdcard0/QspiDB[0]_i_6
+                                                 core0.machine0/iomapper0/sdcard0/QspiDB[0]_i_8
+                                                 core0.machine0/iomapper0/sdcard0/QspiDB[0]_i_9
+                                                 core0.machine0/iomapper0/sdcard0/QspiDB[3]_i_3
+                                                 core0.machine0/iomapper0/sdcard0/QspiDB[3]_i_4
+                                                 core0.machine0/iomapper0/sdcard0/QspiDB[3]_i_5
+                                                 core0.machine0/iomapper0/sdcard0/QspiDB[3]_i_6
+                                                 core0.machine0/iomapper0/sdcard0/QspiDB[3]_i_7
+                                                 core0.machine0/iomapper0/sdcard0/QspiDB[3]_i_8
+                                                 core0.machine0/iomapper0/sdcard0/QspiDB_reg[0]
+                                                 core0.machine0/iomapper0/sdcard0/QspiDB_reg[1]
+                                                 core0.machine0/iomapper0/sdcard0/QspiDB_reg[2]
+                                                 core0.machine0/iomapper0/sdcard0/QspiDB_reg[3]]]
+# add_cells_to_pblock pblock_qspi [get_cells [list machine0/iomapper0/sdcard0]]
+resize_pblock pblock_qspi -add {SLICE_X0Y50:SLICE_X31Y99}
 
 
 #set_false_path -from [get_clocks -of_objects [get_pins dotclock1/mmcm_adv_inst/CLKOUT2]] -to [get_clocks -of_objects [get_pins dotclock1/mmcm_adv_inst/CLKOUT3]]
@@ -263,13 +348,6 @@ set_false_path -from [get_pins machine0/iomapper0/block2.framepacker0/buffer_mob
 set_false_path -from [get_pins machine0/iomapper0/block2.framepacker0/buffer_moby_toggle_reg/C] -to [get_pins {machine0/iomapper0/ethernet0/tx_preamble_count_reg[3]/S}]
 set_false_path -from [get_pins machine0/iomapper0/ethernet0/eth_tx_viciv_reg/C] -to [get_pins machine0/iomapper0/ethernet0/eth_tx_trigger_reg/D]
 set_false_path -from [get_pins machine0/iomapper0/ethernet0/eth_rx_buffer_last_used_50mhz_reg/C] -to [get_pins machine0/iomapper0/ethernet0/eth_rx_buffer_last_used_int1_reg/D]
-set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design]
-set_property BITSTREAM.CONFIG.CONFIGRATE 26 [current_design]
-set_property CONFIG_VOLTAGE 3.3 [current_design]
-set_property CFGBVS VCCO [current_design]
-set_property CONFIG_MODE SPIx4 [current_design]
-set_property BITSTREAM.CONFIG.SPI_32BIT_ADDR YES [current_design]
-set_property BITSTREAM.CONFIG.SPI_BUSWIDTH 4 [current_design]
 
 
 set_false_path -from [get_pins machine0/iomapper0/block2.framepacker0/buffer_moby_toggle_reg/C] -to [get_pins {machine0/iomapper0/ethernet0/FSM_onehot_eth_tx_state_reg[4]/CE}]
@@ -282,3 +360,12 @@ set_false_path -from [get_pins machine0/iomapper0/block2.framepacker0/buffer_mob
 set_false_path -from [get_pins machine0/iomapper0/block2.framepacker0/buffer_moby_toggle_reg/C] -to [get_pins {machine0/iomapper0/ethernet0/eth_txd_int_reg[0]/D}]
 set_false_path -from [get_pins machine0/iomapper0/block2.framepacker0/buffer_moby_toggle_reg/C] -to [get_pins machine0/iomapper0/ethernet0/eth_txen_int_reg/D]
 set_false_path -from [get_pins machine0/iomapper0/block2.framepacker0/buffer_moby_toggle_reg/C] -to [get_pins machine0/iomapper0/ethernet0/eth_tx_viciv_reg/D]
+
+
+set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design]
+set_property BITSTREAM.CONFIG.CONFIGRATE 26 [current_design]
+set_property CONFIG_VOLTAGE 3.3 [current_design]
+set_property CFGBVS VCCO [current_design]
+set_property CONFIG_MODE SPIx4 [current_design]
+set_property BITSTREAM.CONFIG.SPI_32BIT_ADDR YES [current_design]
+set_property BITSTREAM.CONFIG.SPI_BUSWIDTH 4 [current_design]

--- a/vivado/nexys4ddr-widget_gen.tcl
+++ b/vivado/nexys4ddr-widget_gen.tcl
@@ -210,6 +210,7 @@ set files [list \
  "[file normalize "$origin_dir/src/vhdl/virtual_to_matrix.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/keyboard_to_matrix.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/mega65kbd_to_matrix.vhdl"]"\
+ "[file normalize "$origin_dir/src/vhdl/mk2_to_mk1.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/matrix_to_ascii.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/widget_to_matrix.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/ps2_to_matrix.vhdl"]"\
@@ -410,11 +411,11 @@ set_property -name "file_type" -value "VHDL" -objects $file_obj
 
 set file "verilog/sid_voice_8580.v"
 set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
-set_property -name "file_type" -value "VERILOG" -objects $file_obj
+set_property -name "file_type" -value "Verilog" -objects $file_obj
 
 set file "verilog/sid_envelope.v"
 set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
-set_property -name "file_type" -value "VERILOG" -objects $file_obj
+set_property -name "file_type" -value "Verilog" -objects $file_obj
 
 set file "vhdl/sid_filters.vhdl"
 set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
@@ -445,6 +446,10 @@ set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
 set_property -name "file_type" -value "VHDL" -objects $file_obj
 
 set file "vhdl/mega65kbd_to_matrix.vhdl"
+set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
+set_property -name "file_type" -value "VHDL" -objects $file_obj
+
+set file "vhdl/mk2_to_mk1.vhdl"
 set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
 set_property -name "file_type" -value "VHDL" -objects $file_obj
 


### PR DESCRIPTION
It is active on the XADC and JA PMOD ports of the NEXYS board.
This module has a different pinout than the single-chip HyperRAM module.
I wonder how I could detect the different modules ???

Support for the DIY Keyboard on JBhi is also enabled.

Widget connection has been moved to JD and JC.