### PR TITLE
Remove some critical warnings

### DIFF
--- a/src/verilog/monitor_ctrl.v
+++ b/src/verilog/monitor_ctrl.v
@@ -50,7 +50,7 @@
 `define MON_CHAR_STATUS       5'h1F
 
 module monitor_ctrl(input clk, input reset, output reg reset_out, 
-                    `MARK_DEBUG input 		   write, (* mark_debug = "true" *) input read, 
+                    `MARK_DEBUG input 		   write, `MARK_DEBUG input read,
 						   `MARK_DEBUG input [4:0] address, 
 						   `MARK_DEBUG input [7:0] di, output reg [7:0] do,
 				output reg [9:0]   history_write_index, output wire history_write, output reg [9:0] history_read_index,

--- a/src/vhdl/audio_clock100.vhdl
+++ b/src/vhdl/audio_clock100.vhdl
@@ -43,6 +43,7 @@ end entity audio_clock;
 architecture synth of audio_clock is
 
   signal locked   : std_logic;     -- MMCM lock status
+  signal clk_60_u : stD_logic;       -- 60MHz unbuffered clock
   signal clk_60 : stD_logic;       -- 60MHz intermediate clock
   signal clk_u    : std_logic;     -- unbuffered output clock
   signal clko_fb  : std_logic;     -- unbuffered feedback clock
@@ -137,7 +138,7 @@ begin
         clkfbstopped    => open,
 --        clkout0         => clk_u,
         clkout0b        => open,
-        clkout1         => clk_60,
+        clkout1         => clk_60_u,
         clkout1b        => open,
         clkout2         => open,
         clkout2b        => open,
@@ -169,6 +170,12 @@ begin
         port map (
             I   => clko_fb,
             O   => clki_fb
+        );
+
+    BUFG_50: unisim.vcomponents.bufg
+        port map (
+            I   => clk_60_u,
+            O   => clk_60
         );
 
     rsto <= not locked;

--- a/src/vhdl/iomapper.vhdl
+++ b/src/vhdl/iomapper.vhdl
@@ -1644,7 +1644,10 @@ begin
   scancode_out<=last_scan_code;
   process(cpuclock,sbcs_en,lscs_en,c65uart_en,ethernetcs_en,sdcardio_en,
           cia1cs_en,cia2cs_en,sd_interface_select_internal,sd_interface_select,sd_interface_select_internal,
-          miso_i,sd_bitbash_mosi_o,mosi_o_sd,miso2_i,sd_bitbash,sclk_o_sd,cia1porta_out,cia1porta_ddr)
+          miso_i,sd_bitbash_mosi_o,mosi_o_sd,miso2_i,sd_bitbash,sclk_o_sd,cia1porta_out,cia1porta_ddr,
+          cia1portb_out,cia1portb_ddr,cpu_hypervisor_mode,sbcs_en,
+          addr_fast,lscs_en,rscs_en,c65uart_en,
+          ethernetcs_en,sdcardio_en,cia1cs_en,cia2cs_en)
   begin
       -- Implement SD card switching
       sclk_o <= '1'; -- This avoids a latch

--- a/src/vhdl/iomapper.vhdl
+++ b/src/vhdl/iomapper.vhdl
@@ -2005,7 +2005,10 @@ begin
   end process;
 
   process (r,w,address,cia1portb_in,cia1porta_out,colourram_at_dc00,
-           sector_buffer_mapped_read)
+           sector_buffer_mapped_read,
+           cpu_hypervisor_mode,sbcs_en,addr_fast,lscs_en,
+           rscs_en,c65uart_en,ethernetcs_en,sdcardio_en,
+           cia1cs_en,cia2cs_en)
     variable temp : unsigned(19 downto 0);
   begin  -- process
 

--- a/src/vhdl/mega65r3.vhdl
+++ b/src/vhdl/mega65r3.vhdl
@@ -1266,15 +1266,15 @@ begin
       hdmired <= v_red;
       hdmigreen <= v_green;
       hdmiblue <= v_blue;
-    end if;
 
-    -- XXX DEBUG: Allow showing audio samples on video to make sure they are
-    -- getting through
-    if portp_drive(2)='1' then
-      vgagreen <= unsigned(audio_left(15 downto 8));
-      vgared <= unsigned(audio_right(15 downto 8));
-      hdmigreen <= unsigned(audio_left(15 downto 8));
-      hdmired <= unsigned(audio_right(15 downto 8));
+      -- XXX DEBUG: Allow showing audio samples on video to make sure they are
+      -- getting through
+      if portp_drive(2)='1' then
+        vgagreen <= unsigned(audio_left(15 downto 8));
+        vgared <= unsigned(audio_right(15 downto 8));
+        hdmigreen <= unsigned(audio_left(15 downto 8));
+        hdmired <= unsigned(audio_right(15 downto 8));
+      end if;
     end if;
     
   end process;    

--- a/src/vhdl/mega65r3.vhdl
+++ b/src/vhdl/mega65r3.vhdl
@@ -47,6 +47,11 @@ entity container is
          kb_io0 : inout std_logic;
          kb_io1 : out std_logic;
          kb_io2 : in std_logic;
+         kb_tck : out std_logic := '0';
+         kb_tdo : in std_logic;
+         kb_tms : out std_logic := '0';
+         kb_tdi : out std_logic := '0';
+         kb_jtagen : out std_logic := '0';
 
          -- Direct joystick lines         
          fa_left : in std_logic;
@@ -69,6 +74,7 @@ entity container is
          -- Expansion/cartridge port
          ----------------------------------------------------------------------
          cart_ctrl_dir : out std_logic;
+         cart_ctrl_en : out std_logic := '0';
          cart_haddr_dir : out std_logic;
          cart_laddr_dir : out std_logic;
          cart_data_en : out std_logic;
@@ -144,6 +150,7 @@ entity container is
          
          hdmi_scl : inout std_logic;
          hdmi_sda : inout std_logic;
+         hdmi_cec_a : inout std_logic := 'Z';
 
          hpd_a : inout std_logic;
          ct_hpd : out std_logic := '1';
@@ -169,6 +176,7 @@ entity container is
          eth_rxdv : in std_logic;
 --         eth_interrupt : in std_logic;
          eth_clock : out std_logic;
+         eth_led : out std_logic_vector(1 downto 1) := "0";
          
          -------------------------------------------------------------------------
          -- Lines for the SDcard interface itself
@@ -177,7 +185,10 @@ entity container is
          sdClock : out std_logic;       -- (sclk_o)
          sdMOSI : out std_logic;      
          sdMISO : in  std_logic;
+         sdCD : in std_logic;
+         sdWP : in std_logic;
 
+         sd2CD : in std_logic;
          sd2reset : out std_logic;
          sd2Clock : out std_logic;       -- (sclk_o)
          sd2MOSI : out std_logic;
@@ -1095,7 +1106,9 @@ begin
   qspidb <= qspidb_out when qspidb_oe='1' else "ZZZZ";
   qspidb_in <= qspidb;
   
-  process (pixelclock,cpuclock,pcm_clk) is
+  process (pixelclock,cpuclock,pcm_clk,
+           irq,irq_out,nmi,nmi_out,
+           audio_right,audio_left,portp_drive) is
   begin
     vdac_sync_n <= '0';  -- no sync on green
     vdac_blank_n <= '1'; -- was: not (v_hsync or v_vsync); 

--- a/src/vhdl/mega65r3.xdc
+++ b/src/vhdl/mega65r3.xdc
@@ -33,6 +33,12 @@ create_generated_clock -name clock60  [get_pins AUDIO_TONE/CLOCK/MMCM/CLKOUT1]
 # not cause timing violations.
 create_generated_clock -name clock12p228 -source [get_pins AUDIO_TONE/CLOCK/MMCM/CLKOUT1] -divide_by 4 [get_pins AUDIO_TONE/CLOCK/clk_u_reg/Q]
 
+create_generated_clock -name clock1      -source [get_pins clocks1/mmcm_adv0/CLKOUT3]     -divide_by 41 [get_pins m0.machine0/pixel0/phi_1mhz_ubuf_reg/Q]
+create_generated_clock -name clock2      -source [get_pins clocks1/mmcm_adv0/CLKOUT3]     -divide_by 20 [get_pins m0.machine0/pixel0/phi_2mhz_ubuf_reg/Q]
+create_generated_clock -name clock3p5    -source [get_pins clocks1/mmcm_adv0/CLKOUT3]     -divide_by 10 [get_pins m0.machine0/pixel0/phi_3mhz_ubuf_reg/Q]
+
+set_false_path -from [get_clocks clock41] -to [get_clocks clock1]
+
 # TODO: These cause massive timing errors.
 #set_input_delay -clock [get_clocks clock50] -max 15 [get_ports {eth_rxd[1] eth_rxd[0]}]
 #set_input_delay -clock [get_clocks clock50] -min 5  [get_ports {eth_rxd[1] eth_rxd[0]}]

--- a/src/vhdl/pixel_driver.vhdl
+++ b/src/vhdl/pixel_driver.vhdl
@@ -23,8 +23,8 @@ use ieee.numeric_std.all;
 use Std.TextIO.all;
 use work.debugtools.all;
 
---library UNISIM;
---use UNISIM.vcomponents.all;
+library UNISIM;
+use UNISIM.vcomponents.all;
 
 
 entity pixel_driver is
@@ -523,6 +523,14 @@ architecture greco_roman of pixel_driver is
     x"f7",x"f8",x"f8",x"f9",x"f9",x"fa",x"fb",x"fb",x"fc",x"fc",x"fd",x"fd",x"fe",x"fe",x"ff",x"ff"
     );
   
+  signal phi_1mhz_int : std_logic;
+  signal phi_2mhz_int : std_logic;
+  signal phi_3mhz_int : std_logic;
+
+  signal phi_1mhz_ubuf : std_logic;
+  signal phi_2mhz_ubuf : std_logic;
+  signal phi_3mhz_ubuf : std_logic;
+
 begin
 
   assert ( (debug_height_reduction mod 2) = 0) report "debug_height_reduction must be even";
@@ -787,15 +795,27 @@ begin
      );
 
   phi_1mhz_ntsc_out <= phi2_1mhz_ntsc60;
-  phi_1mhz_out <= phi2_1mhz_pal50 when pal50_select_internal='1' else
+  phi_1mhz_int <= phi2_1mhz_pal50 when pal50_select_internal='1' else
                   phi2_1mhz_vga60 when vga60_select_internal='1'
                   else phi2_1mhz_ntsc60;
-  phi_2mhz_out <= phi2_2mhz_pal50 when pal50_select_internal='1' else
+  phi_2mhz_int <= phi2_2mhz_pal50 when pal50_select_internal='1' else
                   phi2_2mhz_vga60 when vga60_select_internal='1'
                   else phi2_2mhz_ntsc60;
-  phi_3mhz_out <= phi2_3mhz_pal50 when pal50_select_internal='1' else
+  phi_3mhz_int <= phi2_3mhz_pal50 when pal50_select_internal='1' else
                   phi2_3mhz_vga60 when vga60_select_internal='1'
                   else phi2_3mhz_ntsc60;
+  process (cpuclock)
+  begin
+     if rising_edge(cpuclock) then
+        phi_1mhz_ubuf <= phi_1mhz_int;
+        phi_2mhz_ubuf <= phi_2mhz_int;
+        phi_3mhz_ubuf <= phi_3mhz_int;
+     end if;
+  end process;
+
+  BUFG_1: unisim.vcomponents.bufg port map (I => phi_1mhz_ubuf, O => phi_1mhz_out);
+  BUFG_2: unisim.vcomponents.bufg port map (I => phi_2mhz_ubuf, O => phi_2mhz_out);
+  BUFG_3: unisim.vcomponents.bufg port map (I => phi_3mhz_ubuf, O => phi_3mhz_out);
 
   cv_hsync <= cv_hsync_pal50 when pal50_select_internal='1' else
               cv_hsync_vga60 when vga60_select_internal='1'


### PR DESCRIPTION
This removes a bunch of warnings from Vivado. Build time is essentially unchanged.