### PR TITLE
Upper palette chars support reverse, blink, underline; rewrote build instructions

### DIFF
--- a/src/vhdl/viciv.vhdl
+++ b/src/vhdl/viciv.vhdl
@@ -4524,17 +4524,16 @@ begin
             glyph_colour_drive(7 downto 4) <= colourramdata(7 downto 4);
           else
             if viciii_extended_attributes='1' then
+              glyph_colour_drive(4) <= colourramdata(6);
+              glyph_bold_drive <= colourramdata(6) and not colourramdata(5);
               if colourramdata(4)='1' then
                 -- Blinking glyph
                 glyph_blink_drive <= '1';
                 if colourramdata(5)='1'
-                  or colourramdata(6)='1'
                   or colourramdata(7)='1' then
                   -- Blinking attributes
                   if viciii_blink_phase='1' then
                     glyph_reverse_drive <= colourramdata(5);
-                    glyph_bold_drive <= colourramdata(6);
-                    glyph_colour_drive(4) <= colourramdata(6);
                     if chargen_y_hold="111" then
                       glyph_underline_drive <= colourramdata(7);
                     end if;
@@ -4547,8 +4546,6 @@ begin
                 -- Non-blinking attributes
                 glyph_visible_drive <= '1';
                 glyph_reverse_drive <= colourramdata(5);
-                glyph_bold_drive <= colourramdata(6);
-                glyph_colour_drive(4) <= colourramdata(6);
                 if chargen_y_hold="111" then
                   glyph_underline_drive <= colourramdata(7);
                 end if;


### PR DESCRIPTION
This change to VIC-III character attributes in the regular color mode causes reverse, blink, and underline to behave identically for both lower palette (non-"bold") and upper/alternate palette ("bold") characters.

Previously, the alt palette bit was being treated as a blinkable attribute, similar to how blink+reverse actually blinks between reverse and non-reverse. Blinking between the two palettes is not useful or intuitive behavior, and it rules out more useful possibilities like blinking an alt palette character on and off. With this change, bit 6 always sets the alt palette with no interaction with blink, and the other attributes behave as expected.

Note that this redefines the `glyph_bold_drive` line to not blink either. This is now defined as "bit 6 (bold) but not bit 5 (reverse)," which is a requirement elsewhere in the logic to enable reverse alt-palette characters.

* Implements this request: https://github.com/MEGA65/mega65-core/issues/715
* Fixes this cursor color bug in the latest ROM: https://github.com/MEGA65/mega65-rom-public/issues/56

Unrelated but included: I have rewritten the core build documentation based on my recent attempt to set up core builds from scratch on a new Linux system.