### PR TITLE
(#713) Fix long delay to openrom

### DIFF
--- a/src/hyppo/main.asm
+++ b/src/hyppo/main.asm
@@ -791,8 +791,6 @@ trybus0:
         dex
         bne morewaiting
 
-        ldx #$03
-
         lda #$c0
         sta $d680
 
@@ -806,6 +804,7 @@ trybus0:
         lda #$01
         sta $d680
 
+        ldx #$03
 @morewaiting2:
         jsr sdwaitawhile
 

--- a/src/hyppo/main.asm
+++ b/src/hyppo/main.asm
@@ -1404,7 +1404,7 @@ l17d:   lda txt_MEGA65ROM,x
         jsr sdwaitawhile
         jsr sdwaitawhile
 
-        jmp sdcarderror
+        jmp go64
 
 ;;         ========================
 


### PR DESCRIPTION
Also allow hyppo to boot to internal openrom if no MEGA65.ROM is found on the sd-card.