### PR TITLE
Repair mouse and paddle in port 2

### DIFF
--- a/src/vhdl/c65uart.vhdl
+++ b/src/vhdl/c65uart.vhdl
@@ -793,10 +793,6 @@ begin  -- behavioural
         when x"1b" =>
           -- @IO:GS $D61B DEBUG:AMIMOUSDETECT READ 1351/amiga mouse auto detection DEBUG
           fastio_rdata <= mouse_debug;
-          -- @IO:GS $D620 UARTMISC:POTAX Read Port A paddle X, without having to fiddle with SID/CIA settings.
-          -- @IO:GS $D621 UARTMISC:POTAY Read Port A paddle Y, without having to fiddle with SID/CIA settings.
-          -- @IO:GS $D622 UARTMISC:POTBX Read Port B paddle X, without having to fiddle with SID/CIA settings.
-          -- @IO:GS $D623 UARTMISC:POTBY Read Port B paddle Y, without having to fiddle with SID/CIA settings.
         when x"1c" =>
           -- @IO:GS $D61C DEBUG:1541PCLSB internal 1541 PC LSB
           fastio_rdata(7 downto 0) <= unsigned(portq_in);
@@ -811,6 +807,10 @@ begin  -- behavioural
         when x"1F" =>
           -- @IO:GS $D61F DEBUG:BUCKYCOPY DUPLICATE Modifier key state (hardware accelerated keyboard scanner).
           fastio_rdata(7 downto 0) <= unsigned(porti);
+          -- @IO:GS $D620 UARTMISC:POTAX Read Port A paddle X, without having to fiddle with SID/CIA settings.
+          -- @IO:GS $D621 UARTMISC:POTAY Read Port A paddle Y, without having to fiddle with SID/CIA settings.
+          -- @IO:GS $D622 UARTMISC:POTBX Read Port B paddle X, without having to fiddle with SID/CIA settings.
+          -- @IO:GS $D623 UARTMISC:POTBY Read Port B paddle Y, without having to fiddle with SID/CIA settings.
         when x"20" => fastio_rdata <= pota_x;
         when x"21" => fastio_rdata <= pota_y;
         when x"22" => fastio_rdata <= potb_x;

--- a/src/vhdl/iomapper.vhdl
+++ b/src/vhdl/iomapper.vhdl
@@ -1825,22 +1825,22 @@ begin
 
       -- Switch POTs between the two SIDs, based on the CIA port A upper
       -- bits.
-      case cia1portb_out(7 downto 6) is
+      case cia1porta_out(7 downto 6) is
         when "01" =>
-          potl_x <= pota_x;
-          potl_y <= pota_y;
-          potr_x <= potb_x;
-          -- Simulate light gun with touch screen
-          if touch1_valid_int='0' then
-            potr_y <= potb_y;
-          else
-            potr_y <= x"00";
-          end if;
-        when others =>
           potr_x <= pota_x;
           potr_y <= pota_y;
           potl_x <= potb_x;
-          potl_y <= potb_y;
+          -- Simulate light gun with touch screen
+          if touch1_valid_int='0' then
+            potl_y <= potb_y;
+          else
+            potl_y <= x"00";
+          end if;
+        when others =>
+          potl_x <= pota_x;
+          potl_y <= pota_y;
+          potr_x <= potb_x;
+          potr_y <= potb_y;
       end case;
 
       -- Reflect CIA lines for IEC bus driverse so that they


### PR DESCRIPTION
The CIA routing of peripheral port analog pins to SID1 was incorrectly wired to CIA PORTB, when it should have been PORTA. Also, the SID selection was backwards: SID1 is "potr", peripheral port 1 is "pota".

I double-checked that we want to label SID1+2 as the "right" SIDs, so swapping "potl" for "potr" is the correct change.

This fixes both known issues with paddles in port 2 and the mouse in port 2.
* https://github.com/MEGA65/mega65-rom-public/issues/35
* https://github.com/MEGA65/mega65-rom-public/issues/52