### PR TITLE
Fix occasional unwanted key repeats

### DIFF
--- a/src/vhdl/matrix_to_ascii.vhdl
+++ b/src/vhdl/matrix_to_ascii.vhdl
@@ -1054,6 +1054,7 @@ begin
               key_num_timeout <= cherry_mx_debounce_time;
               repeat_key <= key_num;
               repeat_key_timer <= repeat_start_timer;
+              repeat_timer_expired <= '0';
               key_valid_countdown <= 1023;
               key_valid <= '0';
               ascii_key <= key_matrix(key_num);


### PR DESCRIPTION
Fixes https://github.com/MEGA65/mega65-core/issues/738

I was able to trigger the unwanted key repeat every few lines of typing at my usual typing speed, and could not trigger it with a screenful of fast typing after the change. The change makes sense in code review. It's not clear just from code review how often one could expect this to happen, but experimentally it feels like a strong improvement.