### PR TITLE
Fix MODKEY labels: right shift is bit 1, left shift is bit 0

### DIFF
--- a/src/vhdl/c65uart.vhdl
+++ b/src/vhdl/c65uart.vhdl
@@ -691,8 +691,8 @@ begin  -- behavioural
           -- @IO:GS $D60A.4 UARTMISC:MODKEYALT ALT key state at top of typing event queue. 1 = held during event.
           -- @IO:GS $D60A.3 UARTMISC:MODKEYMEGA MEGA/C= key state at top of typing event queue. 1 = held during event.
           -- @IO:GS $D60A.2 UARTMISC:MODKEYCTRL CTRL key state at top of typing event queue. 1 = held during event.
-          -- @IO:GS $D60A.1 UARTMISC:MODKEYLSHFT Left shift key state at top of typing event queue. 1 = held during event.
-          -- @IO:GS $D60A.0 UARTMISC:MODKEYRSHFT Right shift key state at top of typing event queue. 1 = held during event.
+          -- @IO:GS $D60A.1 UARTMISC:MODKEYRSHFT Right shift key state at top of typing event queue. 1 = held during event.
+          -- @IO:GS $D60A.0 UARTMISC:MODKEYLSHFT Left shift key state at top of typing event queue. 1 = held during event.
           fastio_rdata(7) <= key_presenting;
           fastio_rdata(6 downto 0) <= unsigned(bucky_key_buffered(6 downto 0));
         when x"0b" =>
@@ -740,8 +740,8 @@ begin  -- behavioural
           -- @IO:GS $D611.4 UARTMISC:MALT ALT key state (immediate; read only).
           -- @IO:GS $D611.3 UARTMISC:MMEGA MEGA/C= key state (immediate; read only).
           -- @IO:GS $D611.2 UARTMISC:MCTRL CTRL key state (immediate; read only).
-          -- @IO:GS $D611.1 UARTMISC:MLSHFT Left shift key state (immediate; read only).
-          -- @IO:GS $D611.0 UARTMISC:MRSHFT Right shift key state (immediate; read only).
+          -- @IO:GS $D611.1 UARTMISC:MRSHFT Right shift key state (immediate; read only).
+          -- @IO:GS $D611.0 UARTMISC:MLSHFT Left shift key state (immediate; read only).
           fastio_rdata(6 downto 0) <= unsigned(porti(6 downto 0));
           fastio_rdata(7) <= matrix_disable_modifiers;
         when x"12" =>


### PR DESCRIPTION
The right shift and left shift labels were inverted. Doc-only change, no VHDL change.