### PR TITLE
FREEZER: Reduce VIC IV Freeze Range; Save Errata Byte Separately

### DIFF
--- a/src/hyppo/freeze.asm
+++ b/src/hyppo/freeze.asm
@@ -4,6 +4,7 @@
 ;;     ---------------------------------------------------------------- */
 
 version_sentinel_str = "VRS"
+version = 1
 
 freeze_to_slot:
         ;; Freeze current running process to the specified slot
@@ -932,14 +933,14 @@ freeze_d070:
         !8 0
 freeze_version:
         !text version_sentinel_str
-        ;; *** NOTE: Update the version below if more values are added to be restored from
+        ;; *** NOTE: Update the version constant if more values are added to be restored from
         ;; the scratch area.  This prevents us restoring values that were not
         ;; actually frozen but just happened to be in a freeze sector when an
         ;; older freeze was made.
-        !8 1
+        !8 version
 freeze_vic_errata:
         !8 0
-        ;; See NOTE above ;)
+        ;; If adding more values here, update the version constant
 freeze_scratch_area_end:
 
 do_freeze_prep_viciv:
@@ -1118,7 +1119,7 @@ freeze_mem_list:
         !8 0
         !8 freeze_prep_none
 
-        ;; VIC-IV, F011 $D000-$D0FF
+        ;; VIC-IV $D000-$D07F
         !32 $ffd3000
         !16 $0080   ; Do not increase this. $D081 controls sd card buffers/etc.
         !8 0        ;  writing to it will cause very bad things to happen.

--- a/src/hyppo/freeze.asm
+++ b/src/hyppo/freeze.asm
@@ -948,7 +948,7 @@ do_freeze_prep_viciv:
         ;; stomped over by the palette saving routines
         lda freeze_d070
         sta $d070
-	rts
+        rts
 
 freeze_region_dmalist:
         !8 $0A ;; F011A format DMA list

--- a/src/hyppo/freeze.asm
+++ b/src/hyppo/freeze.asm
@@ -950,7 +950,6 @@ do_freeze_prep_viciv:
         sta $d070
 	rts
 
-
 freeze_region_dmalist:
         !8 $0A ;; F011A format DMA list
         !8 $80 ;; Source MB option follows


### PR DESCRIPTION
Fixes: https://github.com/MEGA65/mega65-core/issues/753

The freeze_mem_list entry for $FFD3000 ($D000) was extended to include memory locations up to $D100 in an effort to include the new errata byte at $D08F (and, I think, to freeze additional, useful state). Unfortunately, this area includes at least one location that should not be written to when unfreezing: $D081.  Writing to this location can cause changes to the sector buffers that contain the freezer data.  The result of writing there is almost always fatal as the machine is unfrozen with huge parts of the memory basically empty -- including the ROMs.  So that freeze_mem_list entry was reduced back down to only include locations up to $D07F.

To save the errata byte at $D08F, it was added to the freeze_scratch_area which is saved in the first sector of the freeze. However, we can not blindly overwrite $D08F if an older freeze is being unfrozen, so I've added a versioning system to ensure that only values that were supported when the freeze was made are restored.