### PR TITLE
fast_divide.vhdl: Optimize division

### DIFF
--- a/src/vhdl/fast_divide.vhdl
+++ b/src/vhdl/fast_divide.vhdl
@@ -46,6 +46,7 @@ begin
     variable leading_zeros : natural range 0 to 31;
     variable new_dd : unsigned( 35 downto 0);
     variable new_nn : unsigned( 67 downto 0);
+    variable padded_d : unsigned(63 downto 0);
   begin
     if rising_edge(clock) then
       report "state is " & state_t'image(state);
@@ -98,8 +99,9 @@ begin
       if start_over='1' and d /= to_unsigned(0,32) then
         report "Calculating $" & to_hstring(n) & " / $" & to_hstring(d);
         leading_zeros := count_leading_zeros(d);
+        padded_d := d & X"00000000";
         new_dd := (others => '0');
-        new_dd(35 downto 4+leading_zeros) := d(31-leading_zeros downto 0);
+        new_dd(35 downto 4) := padded_d(63-leading_zeros downto 32-leading_zeros);
         new_nn := (others => '0');
         new_nn(35+leading_zeros downto 4+leading_zeros) := n;
         report "Normalised to $" & to_hstring(new_nn(67 downto 36)) & "." &

--- a/src/vhdl/fast_divide.vhdl
+++ b/src/vhdl/fast_divide.vhdl
@@ -20,19 +20,32 @@ entity fast_divide is
 end entity;
 
 architecture wattle_and_daub of fast_divide is
-  type state_t is (idle, normalise, step, preoutput, output);
+  type state_t is (idle, step, output);
   signal state : state_t := idle;
   signal steps_remaining : integer range 0 to 5 := 0;
 
   signal dd : unsigned(35 downto 0) := to_unsigned(0,36);
   signal nn : unsigned(67 downto 0) := to_unsigned(0,68);
-    
+
+  pure function count_leading_zeros(arg : unsigned(31 downto 0)) return natural is
+  begin
+    for i in 0 to 31 loop
+      if arg(31-i) = '1' then
+        return i;
+      end if;
+    end loop;
+    return 0;
+  end function count_leading_zeros;
+
 begin
 
   process (clock) is
     variable temp64 : unsigned(73 downto 0) := to_unsigned(0,74);
     variable temp96 : unsigned(105 downto 0) := to_unsigned(0,106);
     variable f : unsigned(37 downto 0) := to_unsigned(0,38);
+    variable leading_zeros : natural range 0 to 31;
+    variable new_dd : unsigned( 35 downto 0);
+    variable new_nn : unsigned( 67 downto 0);
   begin
     if rising_edge(clock) then
       report "state is " & state_t'image(state);
@@ -44,40 +57,6 @@ begin
           if dd = to_unsigned(0,36) then
             q <= (others => '1');
             busy <= '0';
-          end if;
-        when normalise =>
-          if dd(35)='1' then
-            report "Normalised to $" & to_hstring(nn(67 downto 36)) & "." & to_hstring(nn(35 downto 4)) & "." & to_hstring(nn(3 downto 0))
-              & " / $" & to_hstring(dd(35 downto 4)) & "." & to_hstring(dd(3 downto 0));
-            state <= step;
-          else
-              -- Normalise in not more than 5 cycles
-            if dd(35 downto 20)= to_unsigned(0,16) then
-              dd(35 downto 20) <= dd(19 downto 4);
-              dd(19 downto 0) <= (others => '0');
-              nn(67 downto 20) <= nn(51 downto 4);
-              nn(19 downto 0) <= (others => '0');
-            elsif dd(35 downto 28)= to_unsigned(0,8) then
-              dd(35 downto 12) <= dd(27 downto 4);
-              dd(11 downto 0) <= (others => '0');
-              nn(67 downto 12) <= nn(59 downto 4);
-              nn(11 downto 0) <= (others => '0');
-            elsif dd(35 downto 32) = to_unsigned(0,4) then
-              dd(35 downto 8) <= dd(31 downto 4);
-              dd(7 downto 0) <= (others => '0');
-              nn(67 downto 8) <= nn(63 downto 4);
-              nn(7 downto 0) <= (others => '0');
-            elsif dd(35 downto 34) = to_unsigned(0,2) then
-              dd(35 downto 6) <= dd(33 downto 4);
-              dd(5 downto 0) <= (others => '0');
-              nn(67 downto 6) <= nn(65 downto 4);
-              nn(5 downto 0) <= (others => '0');
-            elsif dd(35)='0' then
-              dd(35 downto 5) <= dd(34 downto 4);
-              dd(4 downto 0) <= (others => '0');
-              nn(67 downto 5) <= nn(66 downto 4);
-              nn(4 downto 0) <= (others => '0');
-            end if;
           end if;
         when step =>
           report "nn=$" & to_hstring(nn(67 downto 36)) & "." & to_hstring(nn(35 downto 4)) & "." & to_hstring(nn(3 downto 0))
@@ -102,17 +81,15 @@ begin
           if steps_remaining /= 0 and dd /= x"FFFFFFFFF" then
             steps_remaining <= steps_remaining - 1;
           else
-            state <= preoutput;
+            state <= output;
           end if;
-        when preoutput =>
+        when output =>
           -- No idea why we need to add one, but we do to stop things like 4/2
           -- giving a result of 1.999999999
           temp64(67 downto 0) := nn;
           temp64(73 downto 68) := (others => '0');
           temp64 := temp64 + 1;
           report "temp64=$" & to_hstring(temp64);
-          state <= output;
-        when output =>
           busy <= '0';
           q <= temp64(67 downto 4);
           state <= idle;
@@ -120,12 +97,17 @@ begin
 
       if start_over='1' and d /= to_unsigned(0,32) then
         report "Calculating $" & to_hstring(n) & " / $" & to_hstring(d);
-        dd(35 downto 4) <= d;
-        dd(3 downto 0) <= (others => '0');
-        nn(35 downto 4) <= n;
-        nn(3 downto 0) <= (others => '0');
-        nn(67 downto 36) <= (others => '0');
-        state <= normalise;
+        leading_zeros := count_leading_zeros(d);
+        new_dd := (others => '0');
+        new_dd(35 downto 4+leading_zeros) := d(31-leading_zeros downto 0);
+        new_nn := (others => '0');
+        new_nn(35+leading_zeros downto 4+leading_zeros) := n;
+        report "Normalised to $" & to_hstring(new_nn(67 downto 36)) & "." &
+          to_hstring(new_nn(35 downto 4)) & "." & to_hstring(new_nn(3 downto 0))
+          & " / $" & to_hstring(new_dd(35 downto 4)) & "." & to_hstring(new_dd(3 downto 0));
+        dd <= new_dd;
+        nn <= new_nn;
+        state <= step;
         steps_remaining <= 5;
         busy <= '1';
       elsif start_over='1' then


### PR DESCRIPTION
The average latency is reduced from 13 clock cycles to 8 clock cycles.

The reduction is achieved by performing the initial normalization in one clock cycle, rather than in five clock cycles. Furthermore, one additional clock cycle at end of calculation is removed (state "preoutput").