### PR TITLE
fix sdcardio: D6A1.3 SDFDC:SILENT seems to have no effect #621

### DIFF
--- a/src/utilities/mega65_config.inc
+++ b/src/utilities/mega65_config.inc
@@ -110,7 +110,7 @@ inputPageIndex:
 ;-------------------------------------------------------------------------------
 ;Chipset tab
 ;-------------------------------------------------------------------------------
-chipsetPageCnt 	=	1
+chipsetPageCnt 	=	2
 
 chipsetOptions0:
 	.byte		$60
@@ -122,13 +122,6 @@ chipsetOptions0:
 	.word		$01f3
 	.defPStr	"date (dd-mmm-yyyy):"
 	.byte		$00, $00, $00
-
-	.byte		$20			;option input type
-	.word		$0020			;offset into config table
-	.byte		$01			;bits for testing/setting
-	.defPStr	"dmagic revision:"	;label
-	.defPStr	'f018 (rom < 910523)'		;option unset
-	.defPStr	"f018b"	;option set
 
 	.byte		$20			;option input type
 	.word		$0004			;offset into config table
@@ -148,19 +141,40 @@ chipsetOptions0:
 	.byte		$00, $00, $00, $00
 
 	.byte		$20			;option input type
-	.word		$000F			;offset into config table
-	.byte		$80			;bits for testing/setting
-	.defPStr	"long fn support:"	;label
-	.defPStr	"disable";option unset
-	.defPStr	'enable';option set
-
-
+	.word		$0004			;offset into config table
+	.byte		$08			;bits for testing/setting
+	.defPStr	"disk image drive noise:"
+	.defPStr	"enable"		;option unset
+	.defPStr	"disable"		;option set
+	
 	.byte		$00			;end of list type
 chipsetOptions0_end:
 	.assert		(chipsetOptions0_end - chipsetOptions0) < 256, error, "Chipset Options 0 too large!"
 
+chipsetOptions1:
+	.byte		$20			;option input type
+	.word		$0020			;offset into config table
+	.byte		$01			;bits for testing/setting
+	.defPStr	"dmagic revision:"	;label
+	.defPStr	'f018 (rom < 910523)'	;option unset
+	.defPStr	"f018b"			;option set
+
+	.byte		$20			;option input type
+	.word		$000F			;offset into config table
+	.byte		$80			;bits for testing/setting
+	.defPStr	"long fn support:"	;label
+	.defPStr	"disable"		;option unset
+	.defPStr	'enable'		;option set
+
+	.byte 		$00			;end of list type
+
+chipsetOptions1_end:
+	.assert		(chipsetOptions1_end - chipsetOptions1) < 256, error, "Chipset Options 1 too large!"
+
+
 chipsetPageIndex:
 	.word		chipsetOptions0
+	.word		chipsetOptions1		
 
 
 ;-------------------------------------------------------------------------------

--- a/src/utilities/mega65_config.s
+++ b/src/utilities/mega65_config.s
@@ -20,6 +20,9 @@
 ;TODO
 ;
 ;HISTORY
+;		13NOV2023	kibo		01.03
+;			-	Add option DISK IMAGE DRIVE NOISE to tab CHIPSET
+;			-	Moved settings for DMAgic and LONG FN SUPPORT to new page
 ;		13NOV2023	dengland	01.02
 ;			-	Do not actually reset the machine when "exiting".  Instead,
 ;				show a message to prompt the user into doing so.
@@ -296,7 +299,7 @@ footerLine:
 	.byte		"                                page  / "
 
 infoText0:
-	.byte		"- version 01.02              B"
+	.byte		"- version 01.03              B"
 infoText1:
 	.if	C64_MODE
 	.byte		"- press f8 for help          B"

--- a/src/vhdl/sdcardio.vhdl
+++ b/src/vhdl/sdcardio.vhdl
@@ -2750,9 +2750,11 @@ begin  -- behavioural
 
                   f_selecta <= '1'; f_selectb <= '1';
                   if f011_ds(2 downto 1) = "00" then
-                    if (f011_ds(0) xor f011_swap_drives) = '0' then
+                    if (f011_ds(0) xor f011_swap_drives) = '0' and 
+                       (use_real_floppy0='1' or silent_sdcard='0') then
                       f_selecta <= '0';
-                    else
+                    elsif (f011_ds(0) xor f011_swap_drives) = '1' and 
+                          (use_real_floppy2='1' or silent_sdcard='0') then
                       f_selectb <= '0';
                     end if;
                   end if;
@@ -2768,9 +2770,11 @@ begin  -- behavioural
 
                   f_selecta <= '1'; f_selectb <= '1';
                   if f011_ds(2 downto 1) = "00" then
-                    if (f011_ds(0) xor f011_swap_drives) = '0' then
+                    if (f011_ds(0) xor f011_swap_drives) = '0' and
+                       (use_real_floppy0='1' or silent_sdcard='0') then
                       f_selecta <= '0';
-                    else
+                    elsif (f011_ds(0) xor f011_swap_drives) = '1' and 
+                          (use_real_floppy2='1' or silent_sdcard='0') then
                       f_selectb <= '0';
                     end if;
                   end if;
@@ -2791,9 +2795,11 @@ begin  -- behavioural
 
                   f_selecta <= '1'; f_selectb <= '1';
                   if f011_ds(2 downto 1) = "00" then
-                    if (f011_ds(0) xor f011_swap_drives) = '0' then
+                    if (f011_ds(0) xor f011_swap_drives) = '0' and
+                       (use_real_floppy0='1' or silent_sdcard='0') then
                       f_selecta <= '0';
-                    else
+                    elsif (f011_ds(0) xor f011_swap_drives) = '1' and 
+                          (use_real_floppy2='1' or silent_sdcard='0') then
                       f_selectb <= '0';
                     end if;
                   end if;


### PR DESCRIPTION
This PR adds a check for the SILENT flag when stepping the head in or out, to really support a silent floppy. The former checks were only doing that for turning the motor on or off, but it was forgotten to also check this for head stepping operations.