### PR TITLE
clear $d076 (SPRENV400) on reset #771

### DIFF
--- a/src/vhdl/viciv.vhdl
+++ b/src/vhdl/viciv.vhdl
@@ -2118,6 +2118,7 @@ begin
       if reset='0' then
         -- Reset sprites to normal behaviour on reset
         sprite_horizontal_tile_enables <= (others => '0');
+        sprite_v400s <= (others => '0');
         sprite_v400_super_msbs <= (others => '0');
         sprite_alpha_blend_enables <= (others => '0');
         sprite_bitplane_enables <= (others => '0');


### PR DESCRIPTION
Clearing $d076 on reset as many programs don't expect V400 to be enabled for sprites. Relevant for some intro disk 3 programs like Char Eddie.