### PR TITLE
Various audio mixing and SID fixes

### DIFF
--- a/src/verilog/sid_voice_8580.v
+++ b/src/verilog/sid_voice_8580.v
@@ -132,29 +132,29 @@ always @(posedge clock) begin
 							(!oscillator[19] && osc_edge) ? 1'b0 :
 							osc_edge;
 							
-      lfsr_noise      <= (oscillator[19] && !osc_edge) ?
-						   {lfsr_noise[21],
-							wave_out[11],
-							lfsr_noise[19],
-							wave_out[10],
-							lfsr_noise[17:15],
-							wave_out[9],
-							lfsr_noise[13:12],
-							wave_out[8],
-							lfsr_noise[10],
-							wave_out[7],
-							lfsr_noise[8:6],
-							wave_out[6],
-							lfsr_noise[4:3],
-							wave_out[5],
-							lfsr_noise[1],
-							wave_out[4],
-							(lfsr_noise[17] ^ lfsr_noise[22] ^ reset ^ `test_ctrl)}
-							: lfsr_noise;
+//      lfsr_noise      <= (oscillator[19] && !osc_edge) ?
+//						   {lfsr_noise[21],
+//							wave_out[11],
+//							lfsr_noise[19],
+//							wave_out[10],
+//							lfsr_noise[17:15],
+//							wave_out[9],
+//							lfsr_noise[13:12],
+//							wave_out[8],
+//							lfsr_noise[10],
+//							wave_out[7],
+//							lfsr_noise[8:6],
+//							wave_out[6],
+//							lfsr_noise[4:3],
+//							wave_out[5],
+//							lfsr_noise[1],
+//							wave_out[4],
+//							(lfsr_noise[17] ^ lfsr_noise[22] ^ reset ^ `test_ctrl)}
+//							: lfsr_noise;
                      
-//		lfsr_noise <= 	(oscillator[19] && !osc_edge) ?
-//							{lfsr_noise[21:0], (lfsr_noise[22] | `test_ctrl) ^ lfsr_noise[17]} :
-//							lfsr_noise;
+		lfsr_noise <= 	(oscillator[19] && !osc_edge) ?
+							{lfsr_noise[21:0], (lfsr_noise[22] | `test_ctrl) ^ lfsr_noise[17]} :
+							lfsr_noise;
     end
 end
 

--- a/src/verilog/sid_voice_8580.v
+++ b/src/verilog/sid_voice_8580.v
@@ -160,18 +160,33 @@ end
 
 // Waveform Output Selector
 always @(posedge (clock)) begin
-	case (control[7:4])
-		4'b0001: wave_out = triangle;
-		4'b0010: wave_out = sawtooth;
-		4'b1010: wave_out = supersawtooth;
-		4'b0011: wave_out = {st_out, 4'b1111};
-		4'b0100: wave_out = pulse;
-		4'b0101: wave_out = {p_t_out, 4'b1111}	 & pulse;
-		4'b0110: wave_out = {ps_out, 4'b1111}  & pulse;
-		4'b0111: wave_out = {pst_out, 4'b1111}	 & pulse;
-		4'b1000: wave_out = noise;
-		//default: wave_out = 0;
-	endcase
+	//case (control[7:4])
+	//	4'b0001: wave_out = triangle;
+	//	4'b0010: wave_out = sawtooth;
+	//	4'b1010: wave_out = supersawtooth;
+	//	4'b0011: wave_out = {st_out, 4'b1111};
+	//	4'b0100: wave_out = pulse;
+	//	4'b0101: wave_out = {p_t_out, 4'b1111}	 & pulse;
+	//	4'b0110: wave_out = {ps_out, 4'b1111}  & pulse;
+	//	4'b0111: wave_out = {pst_out, 4'b1111}	 & pulse;
+	//	4'b1000: wave_out = noise;
+	//	//default: wave_out = 0;
+	//endcase
+	if (control[7:4]) begin
+		wave_out = 12'hfff;
+		if (`tri_ctrl) begin
+			wave_out = wave_out & triangle;
+		end
+		if (`saw_ctrl) begin
+			wave_out = wave_out & sawtooth;
+		end
+		if (`pulse_ctrl) begin
+			wave_out = wave_out & pulse;
+		end
+		if (`noise_ctrl) begin
+			wave_out = wave_out & noise;
+		end
+	end
 end
 
 

--- a/src/vhdl/audio_complex.vhdl
+++ b/src/vhdl/audio_complex.vhdl
@@ -83,7 +83,7 @@ entity audio_complex is
     -- Master PCM clock for the modems (1.8V and 8KHz instead)
     pcm_modem_clk : out std_logic := '0';
     pcm_modem_sync : out std_logic := '0';
-	    -- And slave PCM clock for devices that need it
+    -- And slave PCM clock for devices that need it
     -- (there is a problem with the QC25AU refusing to accept AT+QDAI=1,1,0,4,0
     -- to set PCM to slave mode, for example)
     pcm_modem_clk_in : in std_logic;

--- a/src/vhdl/audio_complex.vhdl
+++ b/src/vhdl/audio_complex.vhdl
@@ -201,21 +201,21 @@ architecture elizabethan of audio_complex is
   
   -- add two signed integers, peak if overflow, used to try and fix the SIDs
   -- hardcoding this to 16 bits because i'm lazy ngl
-  subtype signed16 is signed(15 downto 0);
-  function add_with_ovf(a : signed16; b : signed16) return signed16 is
-    variable resized_a, resized_b, add_result : signed(16 downto 0) := (others => '0'); -- vars with more bits for overflow check
+  subtype signed18 is signed(17 downto 0);
+  function add_with_ovf(a : signed18; b : signed18) return signed18 is
+    variable resized_a, resized_b, add_result : signed(18 downto 0) := (others => '0'); -- vars with more bits for overflow check
   begin
-    resized_a := resize(a, 17);
-    resized_b := resize(b, 17);
+    resized_a := resize(a, 19);
+    resized_b := resize(b, 19);
     add_result := resized_a + resized_b;
-    if add_result(16) /= add_result(15) then
-      if add_result(16) = '1' then
-        add_result(15 downto 0) := x"8000";
+    if add_result(18) /= add_result(17) then
+      if add_result(18) = '1' then
+        add_result(17 downto 0) := o"400000";
       else
-        add_result(15 downto 0) := x"7FFF";
+        add_result(17 downto 0) := o"377777";
       end if;
     end if;
-    return add_result(15 downto 0);
+    return add_result(17 downto 0);
   end function; 
   
 begin
@@ -452,8 +452,8 @@ begin
       
       -- Combine the pairs of SIDs     
       -- use the overflow checking addition to be safe 
-      leftsid_audio_combined(17 downto 2) <= add_with_ovf(leftsid_audio(17 downto 2), frontsid_audio(17 downto 2));
-      rightsid_audio_combined(17 downto 2) <= add_with_ovf(rightsid_audio(17 downto 2), backsid_audio(17 downto 2));
+      leftsid_audio_combined <= add_with_ovf(leftsid_audio, frontsid_audio);
+      rightsid_audio_combined <= add_with_ovf(rightsid_audio, backsid_audio);
 
       if cpu_pcm_bypass='0' then
         ampPWM_l_in <= headphones_left_out;

--- a/src/vhdl/audio_mixer.vhdl
+++ b/src/vhdl/audio_mixer.vhdl
@@ -107,7 +107,8 @@ begin
                                              volume : unsigned(15 downto 0))
       return signed is
       variable value_unsigned : unsigned(15 downto 0);
-      variable result_unsigned : unsigned(31 downto 0);
+      variable result_unsigned : unsigned(32 downto 0);
+      variable actual_result_unsigned : unsigned(31 downto 0);
       variable result : signed(15 downto 0);
     begin
 
@@ -116,8 +117,9 @@ begin
       else
         value_unsigned := unsigned(value);
       end if;
-      
-      result_unsigned := value_unsigned * volume;
+      -- fix for peak values being $8001 and $7FFE, ignore the wacky size fix
+      result_unsigned := value_unsigned * (('0' & volume) + 1);
+      actual_result_unsigned := result_unsigned(31 downto 0);
 
       if value(15) = '1' then
         result_unsigned(31 downto 16) := (not result_unsigned(31 downto 16)) + 1;

--- a/src/vhdl/audio_mixer.vhdl
+++ b/src/vhdl/audio_mixer.vhdl
@@ -215,7 +215,11 @@ begin
           if mix_check_ovf(16) = mix_check_ovf(15) then
             mixed_value <= mix_check_ovf(15 downto 0);
           else
-            mixed_value <= x"8000";
+            if mix_check_ovf(16) = '1' then
+              mixed_value <= x"8000";
+            else
+              mixed_value <= x"7FFF";
+            end if;
           end if;
 
           -- Request next mix coefficient

--- a/src/vhdl/audio_mixer.vhdl
+++ b/src/vhdl/audio_mixer.vhdl
@@ -74,7 +74,6 @@ architecture elizabethan of audio_mixer is
   signal output_channel : integer range 0 to 15 := 0;
   
   signal mixed_value : signed(15 downto 0) := x"0000";
-
   signal dummy : unsigned(15 downto 0) := x"0000";
 
   signal volume_knob1_last : unsigned(15 downto 0) := x"8000";
@@ -101,29 +100,32 @@ begin
     variable src_temp : unsigned(15 downto 0);
     variable mix_temp : integer;
 
+    -- values to check if the mixer overflows
+    variable mix_a, mix_b, mix_check_ovf : signed(16 downto 0) := (others => '0');
+
     function multiply_by_volume_coefficient( value : signed(15 downto 0);
                                              volume : unsigned(15 downto 0))
       return signed is
       variable value_unsigned : unsigned(15 downto 0);
       variable result_unsigned : unsigned(31 downto 0);
-      variable result : signed(31 downto 0);
+      variable result : signed(15 downto 0);
     begin
-      if (value(15)='0') then
-        value_unsigned(14 downto 0) := unsigned(value(14 downto 0));
-      else
-        value_unsigned(14 downto 0) := (not unsigned(value(14 downto 0)) + 1);
-      end if;
-      value_unsigned(15) := '0';
 
+      if value(15) = '1' then
+        value_unsigned := unsigned((not value) + 1);
+      else
+        value_unsigned := unsigned(value);
+      end if;
+      
       result_unsigned := value_unsigned * volume;
 
-      if value(15)='1' then
-        result_unsigned := (not result_unsigned) + 1;
+      if value(15) = '1' then
+        result_unsigned(31 downto 16) := (not result_unsigned(31 downto 16)) + 1;
       end if;
 
-      result := signed(result_unsigned);
-
-      return result(31 downto 16);
+      result := signed(result_unsigned(31 downto 16));
+      
+      return result;
       
     end function;   
     
@@ -204,7 +206,18 @@ begin
           if state = 15 then
             source14_volume <= ram_rdata(31 downto 16);
           end if;
-          mixed_value <= mixed_value + multiply_by_volume_coefficient(srcs(state - 1),ram_rdata(31 downto 16));
+          
+          -- compute mixing in a variable to check for overflow
+          mix_a := resize(mixed_value,17);
+          mix_b := resize(multiply_by_volume_coefficient(srcs(state - 1),ram_rdata(31 downto 16)),17);
+          mix_check_ovf := mix_a + mix_b;
+          -- if we do overflow then peak at $8000
+          if mix_check_ovf(16) = mix_check_ovf(15) then
+            mixed_value <= mix_check_ovf(15 downto 0);
+          else
+            mixed_value <= x"8000";
+          end if;
+
           -- Request next mix coefficient
           if state /= 15 then
             ram_raddr <= state + output_offset + 1;


### PR DESCRIPTION
Improves the 8580 SID waveform selector to function as a logical AND.
Fixes multiplication and addition issues in audio_mixer.vhdl and audio_complex.vhdl.

Resolves #793 and #631. Supersedes #794.