### PR TITLE
Fix pblock placement for "generated" components

### DIFF
--- a/src/vhdl/mega65r4.xdc
+++ b/src/vhdl/mega65r4.xdc
@@ -349,6 +349,10 @@ set_property -dict {PACKAGE_PIN AA6 IOSTANDARD LVCMOS33 PULLUP FALSE SLEW FAST D
 set_property -dict {PACKAGE_PIN W5 IOSTANDARD LVCMOS33 PULLUP FALSE SLEW FAST DRIVE 16} [get_ports sdram_dq[13]]
 set_property -dict {PACKAGE_PIN AB6 IOSTANDARD LVCMOS33 PULLUP FALSE SLEW FAST DRIVE 16} [get_ports sdram_dq[14]]
 set_property -dict {PACKAGE_PIN Y3 IOSTANDARD LVCMOS33 PULLUP FALSE SLEW FAST DRIVE 16} [get_ports sdram_dq[15]]
+# Place SDRAM close to I/O pins
+create_pblock pblock_sdram
+add_cells_to_pblock pblock_sdram [get_cells [list *.sdramctrl0]]
+resize_pblock pblock_sdram -add {SLICE_X150Y100:SLICE_X163Y149}
 
 # Constrain input and output times for SDRAM pins
 # DQ pins must have an input delay in a fairly narrow range from about 2.9ns to 5.8ns.
@@ -414,7 +418,7 @@ set_property -dict {PACKAGE_PIN B22 IOSTANDARD LVCMOS33 PULLUP FALSE} [get_ports
 set_property -dict {PACKAGE_PIN C22 IOSTANDARD LVCMOS33 PULLUP FALSE} [get_ports hr_cs0]
 # Place HyperRAM close to I/O pins
 create_pblock pblock_hyperram
-add_cells_to_pblock pblock_hyperram [get_cells [list hyperram0]]
+add_cells_to_pblock pblock_hyperram [get_cells [list *.hram0]]
 resize_pblock pblock_hyperram -add {SLICE_X0Y186:SLICE_X35Y224}
 resize_pblock pblock_hyperram -add {SLICE_X8Y175:SLICE_X23Y186}
 

--- a/src/vhdl/mega65r5.xdc
+++ b/src/vhdl/mega65r5.xdc
@@ -108,7 +108,7 @@ set_property -dict {PACKAGE_PIN K18 IOSTANDARD LVCMOS33} [get_ports {cart_a[1]}]
 set_property -dict {PACKAGE_PIN K19 IOSTANDARD LVCMOS33} [get_ports {cart_a[0]}]
 # Place Cartidge near IO Pins
 create_pblock pblock_cart
-add_cells_to_pblock pblock_cart [get_cells [list slow_devices0/cartport0]]
+add_cells_to_pblock pblock_cart [get_cells [list *.slow_devices0/cartport0]]
 resize_pblock pblock_cart -add {SLICE_X0Y137:SLICE_X7Y185}
 
 # C65 Keyboard
@@ -124,7 +124,7 @@ set_property -dict {PACKAGE_PIN C13 IOSTANDARD LVCMOS33} [get_ports kb_io2]
 set_property -dict {PACKAGE_PIN B13 IOSTANDARD LVCMOS33} [get_ports kb_jtagen]
 # Place Keyboard close to I/O pins
 create_pblock pblock_kbd0
-add_cells_to_pblock pblock_kbd0 [get_cells [list kbd0]]
+add_cells_to_pblock pblock_kbd0 [get_cells [list *.kbd0]]
 resize_pblock pblock_kbd0 -add {SLICE_X0Y225:SLICE_X7Y243}
 
 # Paddles
@@ -353,6 +353,10 @@ set_property -dict {PACKAGE_PIN AA6 IOSTANDARD LVCMOS33 PULLUP FALSE SLEW FAST D
 set_property -dict {PACKAGE_PIN W5 IOSTANDARD LVCMOS33 PULLUP FALSE SLEW FAST DRIVE 16} [get_ports sdram_dq[13]]
 set_property -dict {PACKAGE_PIN AB6 IOSTANDARD LVCMOS33 PULLUP FALSE SLEW FAST DRIVE 16} [get_ports sdram_dq[14]]
 set_property -dict {PACKAGE_PIN Y3 IOSTANDARD LVCMOS33 PULLUP FALSE SLEW FAST DRIVE 16} [get_ports sdram_dq[15]]
+# Place SDRAM close to I/O pins
+create_pblock pblock_sdram
+add_cells_to_pblock pblock_sdram [get_cells [list *.sdramctrl0]]
+resize_pblock pblock_sdram -add {SLICE_X150Y100:SLICE_X163Y149}
 
 # Constrain input and output times for SDRAM pins
 # DQ pins must have an input delay in a fairly narrow range from about 2.9ns to 5.8ns.
@@ -418,7 +422,7 @@ set_property -dict {PACKAGE_PIN B22 IOSTANDARD LVCMOS33 PULLUP FALSE} [get_ports
 set_property -dict {PACKAGE_PIN C22 IOSTANDARD LVCMOS33 PULLUP FALSE} [get_ports hr_cs0]
 # Place HyperRAM close to I/O pins
 create_pblock pblock_hyperram
-add_cells_to_pblock pblock_hyperram [get_cells [list hyperram0]]
+add_cells_to_pblock pblock_hyperram [get_cells [list *.hram0]]
 resize_pblock pblock_hyperram -add {SLICE_X0Y186:SLICE_X35Y224}
 resize_pblock pblock_hyperram -add {SLICE_X8Y175:SLICE_X23Y186}
 


### PR DESCRIPTION
Fix the cell selection criteria for pblocks defined on generated components, in mega65r4.xdc and mega65r5.xdc
I also added a pblock region for the sdram controller next to the sdram interface pins.

Generated bitstream before 
![pblocks not filled](https://github.com/MEGA65/mega65-core/assets/10306667/ce9519a9-51c3-4711-9a5a-77fdfffe2bd1)
And with these changes
![pblocks populated](https://github.com/MEGA65/mega65-core/assets/10306667/432927a0-2e54-4604-ac81-16068557225e)
