### PR TITLE
Changes and additions to make MEGA65 work on the Wukong V2 board.

### DIFF
--- a/src/vhdl/audio_clock.vhdl
+++ b/src/vhdl/audio_clock.vhdl
@@ -84,7 +84,7 @@ begin
         clkout0_duty_cycle      => 0.5,
         clkout0_phase           => 0.0,
         clkout0_use_fine_ps     => false,
-        clkout1_divide          => 20,
+        clkout1_divide          => 20,     -- 1200 / 20 = 60 MHz
         clkout1_duty_cycle      => 0.5,
         clkout1_phase           => 0.0,
         clkout1_use_fine_ps     => false,

--- a/src/vhdl/audio_clock.vhdl
+++ b/src/vhdl/audio_clock.vhdl
@@ -16,6 +16,7 @@
 --------------------------------------------------------------------------------
 
 library ieee;
+use ieee.numeric_std.all;
 use ieee.std_logic_1164.all;
 
 library unisim;
@@ -27,7 +28,7 @@ entity audio_clock is
         ratio   : integer   -- clk to fs frequency ratio
     );
     port (
-
+      select_44100 : in std_logic;
         rsti    : in    std_logic;          -- reset in
         clki    : in    std_logic;          -- reference clock in
         rsto    : out   std_logic;          -- reset out (from MMCM lock status)
@@ -40,16 +41,14 @@ end entity audio_clock;
 architecture synth of audio_clock is
 
     signal locked   : std_logic;     -- MMCM lock status
+    signal clk_60_u : std_logic;     -- 60MHz unbuffered clock
+    signal clk_60   : std_logic;     -- 60MHz intermediate clock
     signal clk_u    : std_logic;     -- unbuffered output clock
     signal clko_fb  : std_logic;     -- unbuffered feedback clock
     signal clki_fb  : std_logic;    -- feedback clock
     signal count    : integer range 0 to ratio-1;
+    signal clk12288_counter : unsigned(26 downto 0) := to_unsigned(0,27);
 
-    -- Assume input clock is 50MHz
-    constant mmcm_vco_mul   : real      := 96.0;  -- 50MHz x 96 = 4.8GHz
-    constant mmcm_vco_div   : integer   := 5;     -- 4.8GHz / 5 = 960 MHz
-    constant mmcm_o_div     : real      := 78.125; -- 960 MHz / 78.125 =
-                                                      -- 12.288 MHz
 
     ----------------------------------------------------------------------
 
@@ -85,7 +84,7 @@ begin
         clkout0_duty_cycle      => 0.5,
         clkout0_phase           => 0.0,
         clkout0_use_fine_ps     => false,
-        clkout1_divide          => 1,
+        clkout1_divide          => 20,
         clkout1_duty_cycle      => 0.5,
         clkout1_phase           => 0.0,
         clkout1_use_fine_ps     => false,
@@ -135,9 +134,9 @@ begin
         clkfbout        => clko_fb,
         clkfboutb       => open,
         clkfbstopped    => open,
-        clkout0         => clk_u,
+        clkout0         => open,
         clkout0b        => open,
-        clkout1         => open,
+        clkout1         => clk_60_u,
         clkout1b        => open,
         clkout2         => open,
         clkout2b        => open,
@@ -171,6 +170,44 @@ begin
             O   => clki_fb
         );
 
+    BUFG_60: unisim.vcomponents.bufg
+        port map (
+            I   => clk_60_u,
+            O   => clk_60
+        );
+
     rsto <= not locked;
 
+    process(clk_60)
+    begin
+      if rising_edge(clk_60) then
+        -- 12.228 MHz is our goal, and we clock at 60MHz
+        -- So we want to add 0.2038 x 2 = 0.4076 of a
+        -- half-clock counter every cycle.
+        -- 27487791 / 2^26 = .409600005
+        -- 60MHz x .409600005 / 2 = 12.288000.137 MHz
+        -- i.e., well within the jitter of everything
+
+        -- N5998A HDMI protocol analyser claims we are producing only 47764 samples
+        -- per second, instead of 48000.
+        -- Also, some TVs might not do 48KHz, so we will make it run-time
+        -- switchable to 44.1KHz.
+        -- This requires an 11.2896 MHz clock instead of 12.288MHz
+        -- 25254408 / 2^26 = 0.376320004
+        -- 60MHz x .376320004 / 2 = 11.289600134
+        -- i.e., with error in the milli-samples-per-second range
+        if select_44100 = '0' then
+          -- 48KHz
+          clk12288_counter <= clk12288_counter + 27487791;
+        else
+          -- 44.1KHz
+          clk12288_counter <= clk12288_counter + 25254408;
+        end if;
+
+
+        -- Then pick out the right bit of our counter to
+        -- get a very-close-to-12.288MHz-indeed clock
+        clk_u <= clk12288_counter(26);
+      end if;
+    end process;
 end architecture synth;

--- a/src/vhdl/clocking50mhz.vhdl
+++ b/src/vhdl/clocking50mhz.vhdl
@@ -20,7 +20,7 @@ entity clocking50mhz is
       clock100   : out std_logic;
       clock135p  : out std_logic;
       clock135n  : out std_logic;
-      clock135n2  : out std_logic;
+      clock270   : out std_logic;
       clock162   : out std_logic;
       clock200   : out std_logic;
       clock324   : out std_logic
@@ -147,11 +147,12 @@ begin
     CLKOUT5_DUTY_CYCLE   => 0.500,
     CLKOUT5_USE_FINE_PS  => FALSE,
 
-    -- CLKOUT6 = CLK_OUT7 = duplicate inverted 135MHz clock for comparison
-    CLKOUT6_DIVIDE       => 6,
-    CLKOUT6_PHASE        => 180.000,
+    -- CLKOUT6 = clock270 = 270MHz
+    CLKOUT6_DIVIDE       => 3,
+    CLKOUT6_PHASE        => 0.000,
     CLKOUT6_DUTY_CYCLE   => 0.500,
     CLKOUT6_USE_FINE_PS  => FALSE,
+
     REF_JITTER1          => 0.010)
   port map
     -- Output clocks
@@ -164,7 +165,7 @@ begin
     CLKOUT3             => clock41,
     CLKOUT4             => clock27,
     CLKOUT5             => clock162,
-    CLKOUT6             => clock135n2,
+    CLKOUT6             => clock270,
     -- Input clock control
     CLKFBIN             => clk_fb,
     CLKIN1              => clock10125mhz,

--- a/src/vhdl/iomapper.vhdl
+++ b/src/vhdl/iomapper.vhdl
@@ -144,7 +144,7 @@ entity iomapper is
         reset_monitor_count : in unsigned(11 downto 0);
 
         porta_pins : inout  std_logic_vector(7 downto 0) := (others => 'Z');
-        portb_pins : in  std_logic_vector(7 downto 0);
+        portb_pins : inout  std_logic_vector(7 downto 0);
         keyboard_column8_out : out std_logic;
         key_left : in std_logic;
         key_up : in std_logic;

--- a/src/vhdl/iomapper.vhdl
+++ b/src/vhdl/iomapper.vhdl
@@ -315,7 +315,7 @@ entity iomapper is
     eth_rxer : in std_logic;
     eth_interrupt : in std_logic;
 
-    ethernet_cpu_arrest : out std_logic;
+    ethernet_cpu_arrest : out std_logic := '0';
 
     -------------------------------------------------------------------------
     -- Lines for the SDcard interface itself
@@ -586,7 +586,7 @@ architecture behavioral of iomapper is
   signal ascii_key_event_count : unsigned(15 downto 0) := x"0000";
 
   signal cia1_irq : std_logic;
-  signal ethernet_irq : std_logic;
+  signal ethernet_irq : std_logic := '1';
   signal uart_irq : std_logic;
 
   signal audio_mix_reg : unsigned(7 downto 0) := x"FF";
@@ -597,7 +597,7 @@ architecture behavioral of iomapper is
   signal pcm_left : signed(15 downto 0) := x"FFFF";
   signal pcm_right : signed(15 downto 0) := x"FFFF";
 
-  signal cpu_ethernet_stream : std_logic;
+  signal cpu_ethernet_stream : std_logic := '0';
 
   signal touch_key1_driver : unsigned(7 downto 0);
   signal touch_key2_driver : unsigned(7 downto 0);
@@ -1199,7 +1199,7 @@ begin
     end generate;
 
 
-  eth0: if target /= megaphoner4 and target /= qmtecha100t and target /= qmtecha200t and target /= qmtechk325t generate
+  eth0: if target /= megaphoner4 and target /= qmtecha100t and target /= qmtecha200t and target /= qmtechk325t and target /= wukong generate
     ethernet0 : entity work.ethernet
       generic map (
         num_buffers => num_eth_rx_buffers

--- a/src/vhdl/keyboard_complex.vhdl
+++ b/src/vhdl/keyboard_complex.vhdl
@@ -19,7 +19,7 @@ entity keyboard_complex is
 
     -- Keyboard
     porta_pins : inout  std_logic_vector(7 downto 0) := (others => 'Z');
-    portb_pins : in  std_logic_vector(7 downto 0);
+    portb_pins : inout  std_logic_vector(7 downto 0);
     scan_mode : in std_logic_vector(1 downto 0);
     scan_rate : in unsigned(7 downto 0);
     keyboard_restore : in std_logic := '1';

--- a/src/vhdl/keyboard_to_matrix_wukong.vhdl
+++ b/src/vhdl/keyboard_to_matrix_wukong.vhdl
@@ -1,0 +1,140 @@
+use WORK.ALL;
+
+library IEEE;
+use IEEE.STD_LOGIC_1164.ALL;
+use ieee.numeric_std.all;
+use work.debugtools.all;
+
+entity keyboard_to_matrix is
+    port (
+        clk                  : in    std_logic;
+        porta_pins           : inout std_logic_vector(7 downto 0) := (others => 'Z');
+        portb_pins           : inout std_logic_vector(7 downto 0) := (others => 'Z');
+        keyboard_column8_out : out   std_logic := '1';
+        key_left             : in    std_logic;
+        key_up               : in    std_logic;
+        scan_mode            : in    std_logic_vector(1 downto 0);
+        scan_rate            : in    unsigned(7 downto 0);
+        -- Virtualised keyboard matrix
+        matrix_col           : out   std_logic_vector(7 downto 0) := (others => '1');
+        matrix_col_idx       : in    integer range 0 to 8
+    );
+
+end keyboard_to_matrix;
+
+architecture behavioral of keyboard_to_matrix is
+    -- Scan slow enough for the keyboard (rate is set via scan_rate)
+    -- Actual scan rate = CPU clock / scan_rate.
+    signal scan_phase : integer range 0 to 15        := 0;
+    signal keyram_wea : std_logic_vector(7 downto 0) := (others => '0');
+    signal matrix_dia : std_logic_vector(7 downto 0) := (others => '1');
+begin
+  
+    kb_kmm: entity work.kb_matrix_ram
+        port map (
+            clkA => clk,
+            addressa => scan_phase,
+            dia => matrix_dia,
+            wea => keyram_wea,
+            addressb => matrix_col_idx,
+            dob => matrix_col
+        );
+
+    process (clk)
+        variable counter    : integer range 0 to 255       := 0;
+        variable state      : integer range 0 to 15        := 0;
+        variable column     : integer range 0 to 7         := 0;
+        variable portb0     : std_logic_vector(7 downto 0) := (others => '1');
+        variable portb1     : std_logic_vector(7 downto 0) := (others => '1');
+        variable portb2     : std_logic_vector(7 downto 0) := (others => '1');
+    begin
+        if rising_edge(clk) then
+
+            keyram_wea <= (others => '0');
+            matrix_dia <= (others => '1');
+            scan_phase <= 0;
+
+            -- Scan physical keyboard
+            if counter = 0 then
+
+                if state = 0 then
+                    -- Clear output.
+                    porta_pins <= (others => 'Z');
+                    counter := 32;
+                    state := 1;
+
+                elsif state = 1 then
+                    -- Clear output.
+                    portb_pins <= (others => '1');
+                    counter := 32;
+                    state := 2;
+
+                elsif state = 2 then
+                    -- Clear output.
+                    portb_pins <= (others => 'Z');
+                    counter := 32;
+                    state := 3;
+
+                elsif state = 3 then
+                    -- Clear output.
+                    porta_pins <= (others => '1');
+                    counter := 32;
+                    state := 4;
+
+                elsif state = 4 then
+                    -- Wait until input clear.
+                    if portb_pins = "11111111" then
+                        state := 5;
+                    end if;
+
+                elsif state = 5 then
+                    -- Activate column.
+                    case column is
+                        when 0 => porta_pins <= "11111110";
+                        when 1 => porta_pins <= "11111101";
+                        when 2 => porta_pins <= "11111011";
+                        when 3 => porta_pins <= "11110111";
+                        when 4 => porta_pins <= "11101111";
+                        when 5 => porta_pins <= "11011111";
+                        when 6 => porta_pins <= "10111111";
+                        when 7 => porta_pins <= "01111111";
+                    end case;
+                    counter := 64;
+                    state := 6;
+
+                elsif state = 6 then
+                    -- Read port B.
+                    portb0 := portb_pins;
+                    counter := 64;
+                    state := 7;
+
+                elsif state = 7 then
+                    -- Read port B.
+                    portb1 := portb_pins;
+                    counter := 64;
+                    state := 8;
+
+                elsif state = 8 then
+                    -- Read port B.
+                    portb2 := portb_pins;
+
+                    matrix_dia <= portb0 or portb1 or portb2;
+                    keyram_wea <= (others => '1');
+                    scan_phase <= column;
+
+                    if column = 7 then
+                        column := 0;
+                    else
+                        column := column + 1;
+                    end if;
+
+                    counter := 255;
+                    state := 0;
+                end if;
+            else
+                -- Keep counting down to next scan event
+                counter := counter - 1;
+            end if;
+        end if;
+    end process;
+end behavioral;

--- a/src/vhdl/machine.vhdl
+++ b/src/vhdl/machine.vhdl
@@ -191,7 +191,7 @@ entity machine is
          -- CIA1 ports for keyboard and joysticks
          -------------------------------------------------------------------------
          porta_pins : inout  std_logic_vector(7 downto 0) := (others => 'Z');
-         portb_pins : in  std_logic_vector(7 downto 0);
+         portb_pins : inout  std_logic_vector(7 downto 0);
          keyleft : in std_logic;
          keyup : in std_logic;
          keyboard_column8 : out std_logic := '1';

--- a/src/vhdl/wukong.vhdl
+++ b/src/vhdl/wukong.vhdl
@@ -1,1081 +1,536 @@
-----------------------------------------------------------------------------------
--- Company: 
--- Engineer: 
--- 
--- Create Date:    22:30:37 12/10/2013 
--- Design Name: 
--- Module Name:    container - Behavioral 
--- Project Name: 
--- Target Devices: 
--- Tool versions: 
--- Description: 
+--------------------------------------------------------------------------------
+-- Company:
+-- Engineer:
 --
--- Dependencies: 
+-- Create Date:    22:30:37 12/10/2013
+-- Design Name:
+-- Module Name:    container - Behavioral
+-- Project Name:
+-- Target Devices:
+-- Tool versions:
+-- Description:
 --
--- Revision: 
+-- Dependencies:
+--
+-- Revision:
 -- Revision 0.01 - File Created
--- Additional Comments: 
+-- Additional Comments:
 --
-----------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
 library IEEE;
-use IEEE.STD_LOGIC_1164.ALL;
-use ieee.numeric_std.all;
-use Std.TextIO.all;
+use IEEE.std_logic_1164.all;
+use IEEE.numeric_std.all;
+
+library UNISIM;
+use UNISIM.vcomponents.all;
+
+library STD;
+use STD.textio.all;
+
 use work.cputypes.all;
 use work.types_pkg.all;
 
--- Uncomment the following library declaration if using
--- arithmetic functions with Signed or Unsigned values
---use IEEE.NUMERIC_STD.ALL;
-
--- Uncomment the following library declaration if instantiating
--- any Xilinx primitives in this code.
-library UNISIM;
-use UNISIM.VComponents.all;
-
 entity container is
-  Port ( CLK_IN : STD_LOGIC;         
-         btnCpuReset : in  STD_LOGIC;
---         irq : in  STD_LOGIC;
---         nmi : in  STD_LOGIC;
+  port (
+    clk_in       : in std_logic;
+    reset_button : in std_logic;
 
+    -- Keyboard.
+    porta_pins : inout std_logic_vector(7 downto 0);
+    portb_pins : inout std_logic_vector(7 downto 0);
 
-         debug : out std_logic_vector(4 downto 0);
-         
-         KEY1 : in std_logic;
-         
-         ----------------------------------------------------------------------
-         -- keyboard/joystick 
-         ---------------------------------------------------------------------
-         
---         -- Interface for physical keyboard
---         kb_io0 : out std_logic;
---         kb_io1 : out std_logic;
---         kb_io2 : in std_logic;
-         porta_pins : inout std_logic_vector(7 downto 0);
-         portb_pins : inout std_logic_vector(7 downto 0);
+    -- Joysticks.
+    fa_left  : in std_logic;
+    fa_right : in std_logic;
+    fa_up    : in std_logic;
+    fa_down  : in std_logic;
+    fa_fire  : in std_logic;
+    fb_left  : in std_logic;
+    fb_right : in std_logic;
+    fb_up    : in std_logic;
+    fb_down  : in std_logic;
+    fb_fire  : in std_logic;
 
-         ---------------------------------------------------------------------------
-         -- IO lines to QSPI config flash (used so that we can update bitstreams)
-         ---------------------------------------------------------------------------
-         QspiDB : inout unsigned(3 downto 0) := (others => '0');
-         QspiCSn : out std_logic;
+    -- HDMI.
+    tmds_data_p : out std_logic_vector(2 downto 0);
+    tmds_data_n : out std_logic_vector(2 downto 0);
+    tmds_clk_p  : out std_logic;
+    tmds_clk_n  : out std_logic;
 
-         ---------------------------------------------------------------------------
-         -- Dummy VGA output for debug
-         ---------------------------------------------------------------------------
-         vdac_clk : out std_logic;
-         vdac_sync_n : out std_logic; -- tie low
-         vdac_blank_n : out std_logic; -- tie high
-         vsync : out  STD_LOGIC;
-         hsync : out  STD_LOGIC;
-         vgared : out  UNSIGNED (7 downto 0);
-         vgagreen : out  UNSIGNED (7 downto 0);
-         vgablue : out  UNSIGNED (7 downto 0);
+    -- QSPI flash.
+    qspi_db  : inout unsigned(3 downto 0);
+    qspi_csn : out   std_logic;
 
-         
-         ---------------------------------------------------------------------------
-         -- IO lines to the ethernet controller
-         ---------------------------------------------------------------------------
---         eth_mdio : inout std_logic;
---         eth_mdc : out std_logic;
---         eth_reset : out std_logic;
---         eth_rxd : in unsigned(1 downto 0);
---         eth_txd : out unsigned(1 downto 0);
---         eth_rxer : in std_logic;
---         eth_txen : out std_logic;
---         eth_rxdv : in std_logic;
---         eth_interrupt : in std_logic;
---         eth_clock : out std_logic;
-         
-         -------------------------------------------------------------------------
-         -- Lines for the SDcard interface itself
-         -------------------------------------------------------------------------
-         sdReset : out std_logic := '0';  -- must be 0 to power SD controller (cs_bo)
-         sdClock : out std_logic;       -- (sclk_o)
-         sdMOSI : out std_logic;      
-         sdMISO : in  std_logic;
+    -- Internal SD-card.
+    int_sd_reset : out std_logic;
+    int_sd_clock : out std_logic;
+    int_sd_mosi  : out std_logic;
+    int_sd_miso  : in  std_logic;
 
-         sd2Reset : out std_logic;
-         sd2Clock : out std_logic;       -- (sclk_o)
-         sd2MOSI : out std_logic;
-         sd2MISO : in std_logic;
+    -- Serial monitor.
+    uart_txd : out std_logic;
+    rsrx     : in  std_logic;
 
-         -- Left and right headphone port audio
---         pwm_l : out std_logic;
---         pwm_r : out std_logic;
-
-         -- internal speaker
---         pcspeaker_left : out std_logic;
---         pcspeaker_muten : out std_logic;
-         
-         -- PMOD connectors on the MEGA65 R2 main board
---         p1lo : inout std_logic_vector(3 downto 0);
---         p1hi : inout std_logic_vector(3 downto 0);
---         p2lo : inout std_logic_vector(3 downto 0);
---         p2hi : inout std_logic_vector(3 downto 0);
-         
-         ----------------------------------------------------------------------
-         -- Floppy drive interface
-         ----------------------------------------------------------------------
---         f_density : out std_logic := '1';
---         f_motor : out std_logic := '1';
---         f_select : out std_logic := '1';
---         f_stepdir : out std_logic := '1';
---         f_step : out std_logic := '1';
---         f_wdata : out std_logic := '1';
---         f_wgate : out std_logic := '1';
---         f_side1 : out std_logic := '1';
---         f_index : in std_logic;
---         f_track0 : in std_logic;
---         f_writeprotect : in std_logic;
---         f_rdata : in std_logic;
---         f_diskchanged : in std_logic;
-
-         led : out std_logic;
-         led2 : out std_logic;
-
-         TMDS_data_p : out STD_LOGIC_VECTOR(2 downto 0);
-         TMDS_data_n : out STD_LOGIC_VECTOR(2 downto 0);
-         TMDS_clk_p : out STD_LOGIC;
-         TMDS_clk_n : out STD_LOGIC;
-         
-         ----------------------------------------------------------------------
-         -- I2C on-board peripherals
-         ----------------------------------------------------------------------
---         fpga_sda : inout std_logic;
---         fpga_scl : inout std_logic;         
-         
-         ----------------------------------------------------------------------
-         -- Serial monitor interface
-         ----------------------------------------------------------------------
-         UART_TXD : out std_logic;
-         RsRx : in std_logic
-         
-         );
+    -- Debug LEDs.
+    led : inout std_logic
+  );
 end container;
 
 architecture Behavioral of container is
 
-  signal reset_high : std_logic := '1';
-  
-  signal irq : std_logic := '1';
-  signal nmi : std_logic := '1';
-  signal irq_combined : std_logic := '1';
-  signal nmi_combined : std_logic := '1';
-  signal irq_out : std_logic := '1';
-  signal nmi_out : std_logic := '1';
-  signal reset_out : std_logic := '1';
-  signal cpu_game : std_logic := '1';
-  signal cpu_exrom : std_logic := '1';
+  signal irq                  : std_logic := '1';
+  signal nmi                  : std_logic := '1';
+  signal reset_out            : std_logic := '1';
+  signal btncpureset          : std_logic := '1';
+  signal cpuclock             : std_logic;
+  signal pixelclock           : std_logic;
+  signal clock27              : std_logic;
+  signal clock270             : std_logic;
+  signal restore_key          : std_logic := '1';
+  signal sector_buffer_mapped : std_logic;
+  signal fpga_temperature     : std_logic_vector(11 downto 0) := (others => '0');
 
-  signal fpga_sda : std_logic := '1';
-  signal fpga_scl : std_logic := '1';
-  signal pcspeaker_muten : std_logic := '1';
-  
-  signal ethclock : std_logic;
-  signal cpuclock : std_logic;
-  signal clock27 : std_logic;
-  signal pixelclock : std_logic; -- i.e., clock81p
-  signal clock81n : std_logic;
-  signal clock100 : std_logic;
-  signal clock135p : std_logic;
-  signal clock135n : std_logic;
-  signal clock135n2 : std_logic;
-  signal clock162 : std_logic;
-  signal clock324 : std_logic;
+  -- QSPI flash.
+  signal qspi_clock  : std_logic;
+  signal qspi_db_oe  : std_logic;
+  signal qspi_db_out : unsigned(3 downto 0);
+  signal qspi_db_in  : unsigned(3 downto 0);
 
-  -- XXX Actually connect to new keyboard
-  signal restore_key : std_logic := '1';
-  -- XXX Note that left and up are active HIGH!
-  -- XXX Plumb these into the MEGA65R2 keyboard protocol receiver
-  signal keyleft : std_logic := '0';
-  signal keyup : std_logic := '0';
-  -- On the R2, we don't use the "real" keyboard interface, but instead the
-  -- widget board interface, so just have these as dummy all-high place holders
-  signal column : std_logic_vector(8 downto 0) := (others => '1');
-  signal row : std_logic_vector(7 downto 0) := (others => '1');
-  
-  
-  signal segled_counter : unsigned(31 downto 0) := (others => '0');
+  -- SYSCTL configuration register.
+  signal portp       : unsigned(7 downto 0);
+  signal portp_drive : unsigned(7 downto 0);
 
-  signal slow_access_request_toggle : std_logic;
-  signal slow_access_ready_toggle : std_logic;
-  signal slow_access_write : std_logic;
-  signal slow_access_address : unsigned(27 downto 0);
-  signal slow_access_wdata : unsigned(7 downto 0);
-  signal slow_access_rdata : unsigned(7 downto 0);
+  -- Audio (PCM).
+  constant clock_frequency      : integer := 40500000;
+  constant target_sample_rate   : integer := 48000;
+  signal audio_left             : std_logic_vector(19 downto 0);
+  signal audio_right            : std_logic_vector(19 downto 0);
+  signal audio_left_slow        : std_logic_vector(19 downto 0);
+  signal audio_right_slow       : std_logic_vector(19 downto 0);
+  signal h_audio_left           : std_logic_vector(19 downto 0);
+  signal h_audio_right          : std_logic_vector(19 downto 0);
+  signal audio_counter          : integer                       := 0;
+  signal sample_ready_toggle    : std_logic                     := '0';
+  signal audio_counter_interval : unsigned(25 downto 0)         := to_unsigned(4 * clock_frequency/target_sample_rate, 26);
+  signal acr_counter            : integer range 0 to 12288      := 0;
+  signal pcm_clk                : std_logic                     := '0';
+  signal pcm_rst                : std_logic                     := '1';
+  signal pcm_clken              : std_logic                     := '0';
+  signal pcm_l                  : std_logic_vector(15 downto 0) := std_logic_vector(to_unsigned(0, 16));
+  signal pcm_r                  : std_logic_vector(15 downto 0) := std_logic_vector(to_unsigned(0, 16));
+  signal pcm_acr                : std_logic                     := '0';
 
-  signal slow_prefetched_address : unsigned(26 downto 0);
-  signal slow_prefetched_data : unsigned(7 downto 0);
-  signal slow_prefetched_request_toggle : std_logic;
-  
-  signal sector_buffer_mapped : std_logic;  
-
-  signal pmoda_dummy :  std_logic_vector(7 downto 0) := (others => '1');
-
-  signal v_vga_hsync : std_logic;
-  signal v_vsync : std_logic;
-  signal v_red : unsigned(7 downto 0);
-  signal v_green : unsigned(7 downto 0);
-  signal v_blue : unsigned(7 downto 0);
-  signal lcd_dataenable : std_logic;
+  -- Video (HDMI).
+  signal dvi_reset       : std_logic := '1';
+  signal dvi_select      : std_logic := '0';
+  signal v_hdmi_hsync    : std_logic;
+  signal v_vsync         : std_logic;
+  signal v_red           : unsigned(7 downto 0);
+  signal v_green         : unsigned(7 downto 0);
+  signal v_blue          : unsigned(7 downto 0);
   signal hdmi_dataenable : std_logic;
-  
-  -- XXX We should read the real temperature and feed this to the DDR controller
-  -- so that it can update timing whenever the temperature changes too much.
-  signal fpga_temperature : std_logic_vector(11 downto 0) := (others => '0');
+  signal tmds            : slv_9_0_t(0 to 2);
 
-  signal fa_left_drive : std_logic;
-  signal fa_right_drive : std_logic;
-  signal fa_up_drive : std_logic;
-  signal fa_down_drive : std_logic;
-  signal fa_fire_drive : std_logic;
-  
-  signal fb_left_drive : std_logic;
-  signal fb_right_drive : std_logic;
-  signal fb_up_drive : std_logic;
-  signal fb_down_drive : std_logic;
-  signal fb_fire_drive : std_logic;
+  -- Slow device bus.
+  signal slow_access_request_toggle : std_logic;
+  signal slow_access_ready_toggle   : std_logic;
+  signal slow_access_write          : std_logic;
+  signal slow_access_address        : unsigned(27 downto 0);
+  signal slow_access_wdata          : unsigned(7 downto 0);
+  signal slow_access_rdata          : unsigned(7 downto 0);
 
-  signal fa_potx : std_logic;
-  signal fa_poty : std_logic;
-  signal fb_potx : std_logic;
-  signal fb_poty : std_logic;
-  signal pot_drain : std_logic;
-
-  signal pot_via_iec : std_logic;
-  
-  signal iec_clk_en_drive : std_logic;
-  signal iec_data_en_drive : std_logic;
-  signal iec_srq_en_drive : std_logic;
-  signal iec_data_o_drive : std_logic;
-  signal iec_reset_drive : std_logic;
-  signal iec_clk_o_drive : std_logic;
-  signal iec_srq_o_drive : std_logic;
-  signal iec_data_i_drive : std_logic;
-  signal iec_clk_i_drive : std_logic;
-  signal iec_srq_i_drive : std_logic;
-  signal iec_atn_drive : std_logic;
-
-  signal pwm_l_drive : std_logic;
-  signal pwm_r_drive : std_logic;
-  signal pcspeaker_left_drive : std_logic;
-
-  signal flopled_drive : std_logic;
-  signal flopmotor_drive : std_logic;
-
-  signal joy3 : std_logic_vector(4 downto 0);
-  signal joy4 : std_logic_vector(4 downto 0);
-
-  signal cart_access_count : unsigned(7 downto 0);
-
-  signal widget_matrix_col_idx : integer range 0 to 15 := 0;
-  signal widget_matrix_col : std_logic_vector(7 downto 0) := (others => '1');
-  signal widget_restore : std_logic := '1';
-  signal widget_capslock : std_logic := '0';
-  signal widget_joya : std_logic_vector(4 downto 0);
-  signal widget_joyb : std_logic_vector(4 downto 0);
-
-  signal fastkey : std_logic;
-  
-  signal expansionram_read : std_logic;
-  signal expansionram_write : std_logic;
-  signal expansionram_rdata : unsigned(7 downto 0);
-  signal expansionram_wdata : unsigned(7 downto 0);
-  signal expansionram_address : unsigned(26 downto 0);
-  signal expansionram_data_ready_strobe : std_logic;
-  signal expansionram_busy : std_logic;
-
-  signal current_cache_line : cache_row_t := (others => (others => '0'));
-  signal current_cache_line_address : unsigned(26 downto 3) := (others => '0');
-  signal current_cache_line_valid : std_logic := '0';
-  signal expansionram_current_cache_line_next_toggle : std_logic := '0';
-
-  
-  signal audio_left : std_logic_vector(19 downto 0);
-  signal audio_right : std_logic_vector(19 downto 0);
-  signal audio_left_slow : std_logic_vector(19 downto 0);
-  signal audio_right_slow : std_logic_vector(19 downto 0);
-  signal h_audio_left : std_logic_vector(19 downto 0);
-  signal h_audio_right : std_logic_vector(19 downto 0);
-  signal spdif_44100 : std_logic;
-  
-  signal porto : unsigned(7 downto 0);
-  signal portp : unsigned(7 downto 0) := x"FB";
-
-  signal qspi_clock : std_logic;
-
-  signal disco_led_en : std_logic := '0';
-  signal disco_led_val : unsigned(7 downto 0);
-  signal disco_led_id : unsigned(7 downto 0);
-
-  signal fm_left : signed(15 downto 0);
-  signal fm_right : signed(15 downto 0);
-
-  signal cart_ctrl_dir : std_logic := 'Z';
-  signal cart_haddr_dir : std_logic := 'Z';
-  signal cart_laddr_dir : std_logic := 'Z';
-  signal cart_data_dir : std_logic := 'Z';
-  signal cart_phi2 : std_logic := 'Z';
-  signal cart_dotclock : std_logic := 'Z';
-  signal cart_reset : std_logic := 'Z';
-
-  signal cart_nmi : std_logic := 'Z';
-  signal cart_irq : std_logic := 'Z';
-  signal cart_dma : std_logic := 'Z';
-
-  -- Default to cartridge lines released
-  signal cart_exrom : std_logic := '1';
-  signal cart_ba : std_logic := '1';
-  signal cart_rw : std_logic := '1';
-  signal cart_roml : std_logic := '1';
-  signal cart_romh : std_logic := '1';
-  signal cart_io1 : std_logic := '1';
-  signal cart_game : std_logic := '1';
-  signal cart_io2 : std_logic := '1';
-
-  signal cart_d : unsigned(7 downto 0) := (others => 'Z');
-  signal cart_d_read : unsigned(7 downto 0) := (others => 'Z');
-  signal cart_a : unsigned(15 downto 0) := (others => 'Z');
-
-  signal eth_mdio : std_logic;
-  signal eth_mdc : std_logic;
-  signal eth_reset : std_logic;
-  signal eth_rxd : unsigned(1 downto 0);
-  signal eth_txd : unsigned(1 downto 0);
-  signal eth_rxer : std_logic;
-  signal eth_txen : std_logic;
-  signal eth_rxdv : std_logic;
-  signal eth_interrupt : std_logic;
-  signal eth_clock : std_logic;  
-
-         -- Direct joystick lines
-  signal fa_left : std_logic := '1';
-  signal fa_right : std_logic := '1';
-  signal fa_up : std_logic := '1';
-  signal fa_down : std_logic := '1';
-  signal fa_fire : std_logic := '1';
-  signal fb_left : std_logic := '1';
-  signal fb_right : std_logic := '1';
-  signal fb_up : std_logic := '1';
-  signal fb_down : std_logic := '1';
-  signal fb_fire : std_logic := '1';
-
-  signal iec_clk_en : std_logic := 'Z';
+  -- CBM floppy serial port (not supported).
+  signal iec_clk_en  : std_logic := 'Z';
   signal iec_data_en : std_logic := 'Z';
-  signal iec_data_o : std_logic := 'Z';
-  signal iec_reset : std_logic := 'Z';
-  signal iec_clk_o : std_logic := 'Z';
-  signal iec_data_i : std_logic := '1';
-  signal iec_clk_i : std_logic := '1';
-  signal iec_atn : std_logic := 'Z';  
+  signal iec_srq_en  : std_logic := 'Z';
+  signal iec_data_o  : std_logic := 'Z';
+  signal iec_srq_o   : std_logic := 'Z';
+  signal iec_reset   : std_logic := 'Z';
+  signal iec_clk_o   : std_logic := 'Z';
+  signal iec_data_i  : std_logic := '1';
+  signal iec_clk_i   : std_logic := '1';
+  signal iec_srq_i   : std_logic := '1';
+  signal iec_atn     : std_logic := 'Z';
 
-  signal hdmired : UNSIGNED (7 downto 0);
-  signal hdmigreen : UNSIGNED (7 downto 0);
-  signal hdmiblue : UNSIGNED (7 downto 0);
-  signal hdmi_int : std_logic;
-  signal hdmi_scl : std_logic;
-  signal hdmi_sda : std_logic;
+  -- Expansion / cartridge port.
+  signal cart_ba   : std_logic             := 'Z';
+  signal cart_rw   : std_logic             := 'Z';
+  signal cart_roml : std_logic             := 'Z';
+  signal cart_romh : std_logic             := 'Z';
+  signal cart_io1  : std_logic             := 'Z';
+  signal cart_io2  : std_logic             := 'Z';
+  signal cart_a    : unsigned(15 downto 0) := (others => 'Z');
 
-  signal red_s   : std_logic_vector(0 downto 0);
-  signal green_s : std_logic_vector(0 downto 0);
-  signal blue_s  : std_logic_vector(0 downto 0);
-  signal clock_s : std_logic_vector(0 downto 0);
-
-  signal red_s_n   : std_logic_vector(0 downto 0);
-  signal green_s_n : std_logic_vector(0 downto 0);
-  signal blue_s_n  : std_logic_vector(0 downto 0);
-  
-  constant clock_frequency : integer := 27000000;
-  constant target_sample_rate : integer := 48000;
-  signal audio_counter : integer := 0;
-  signal sample_ready_toggle : std_logic := '0';
-  signal audio_counter_interval : unsigned(23 downto 0) := to_unsigned(clock_frequency/target_sample_rate,24);
-
-  signal pcm_clk : std_logic := '0';
-  signal pcm_rst : std_logic := '1';
-  signal pcm_clken : std_logic := '0';
-  signal pcm_l : std_logic_vector(15 downto 0) := std_logic_vector(to_unsigned(0,16));
-  signal pcm_r : std_logic_vector(15 downto 0) := std_logic_vector(to_unsigned(0,16));
-  signal pcm_acr : std_logic := '0';
-  signal pcm_n   : std_logic_vector(19 downto 0) := std_logic_vector(to_unsigned(0,20));
-  signal pcm_cts : std_logic_vector(19 downto 0) := std_logic_vector(to_unsigned(0,20));
-  
-  
-  signal hdmi_is_progressive : boolean := true;
-  signal hdmi_is_pal : boolean := true;
-  signal hdmi_is_30khz : boolean := true;
-  signal hdmi_is_limited : boolean := true;
-  signal hdmi_is_widescreen : boolean := true;
-
-  signal vga_blank : std_logic := '0';
-
-  signal tmds : slv_9_0_t(0 to 2);
-  
 begin
 
---STARTUPE2:STARTUPBlock--7Series
-
---XilinxHDLLibrariesGuide,version2012.4
-  STARTUPE2_inst: STARTUPE2
-    generic map(PROG_USR=>"FALSE", --Activate program event security feature.
-                                   --Requires encrypted bitstreams.
-  SIM_CCLK_FREQ=>10.0 --Set the Configuration Clock Frequency(ns) for simulation.
+  -- Xilinx primitibe to allow direct control of the clock signal connected to
+  -- the QSPI flash chip used for configuration of the FPGA.
+  STARTUPE2_inst : STARTUPE2
+    generic map(
+      PROG_USR      => "FALSE", -- Activate program event security feature. Requires encrypted bitstreams.
+      SIM_CCLK_FREQ => 10.0     -- Set the Configuration Clock Frequency(ns) for simulation.
     )
     port map(
---      CFGCLK=>CFGCLK,--1-bit output: Configuration main clock output
---      CFGMCLK=>CFGMCLK,--1-bit output: Configuration internal oscillator
-                              --clock output
---             EOS=>EOS,--1-bit output: Active high output signal indicating the
-                      --End Of Startup.
---             PREQ=>PREQ,--1-bit output: PROGRAM request to fabric output
-             CLK=>'0',--1-bit input: User start-up clock input
-             GSR=>'0',--1-bit input: Global Set/Reset input (GSR cannot be used
-                      --for the port name)
-             GTS=>'0',--1-bit input: Global 3-state input (GTS cannot be used
-                      --for the port name)
-             KEYCLEARB=>'0',--1-bit input: Clear AES Decrypter Key input
-                                  --from Battery-Backed RAM (BBRAM)
-             PACK=>'0',--1-bit input: PROGRAM acknowledge input
+      --CFGCLK    => CFGCLK,     -- 1-bit output: Configuration main clock output
+      --CFGMCLK   => CFGMCLK,    -- 1-bit output: Configuration internal oscillator clock output
+      --EOS       => EOS,        -- 1-bit output: Active high output signal indicating the End Of Startup.
+      --PREQ      => PREQ,       -- 1-bit output: PROGRAM request to fabric output
+      CLK       => '0',        -- 1-bit input: User start-up clock input
+      GSR       => '0',        -- 1-bit input: Global Set/Reset input (GSR cannot be used for the port name)
+      GTS       => '0',        -- 1-bit input: Global 3-state input (GTS cannot be used for the port name)
+      KEYCLEARB => '0',        -- 1-bit input: Clear AES Decrypter Key input from Battery-Backed RAM (BBRAM)
+      PACK      => '0',        -- 1-bit input: PROGRAM acknowledge input
+      USRCCLKO  => qspi_clock, -- 1-bit input: User CCLK input
+      USRCCLKTS => '0',        -- 1-bit input: User CCLK 3-state enable input
+      USRDONEO  => '1',        -- 1-bit input: User DONE pin output control
+      USRDONETS => '1'         -- 1-bit input: User DONE 3-state enable output DISABLE
+    );
 
-             -- Put CPU clock out on the QSPI CLOCK pin
-             USRCCLKO=>qspi_clock,--1-bit input: User CCLK input
-             USRCCLKTS=>'0',--1-bit input: User CCLK 3-state enable input
+  -- Clocks.
+  clocks : entity work.clocking50mhz
+    port map(
+      clk_in   => clk_in,
+      clock27  => clock27,    --   27   MHz
+      clock41  => cpuclock,   --   40.5 MHz
+      clock81p => pixelclock, --   81   MHz
+      clock270 => clock270    --  270   MHz
+    );
 
-             -- Assert DONE pin
-             USRDONEO=>'1',--1-bit input: User DONE pin output control
-             USRDONETS=>'1' --1-bit input: User DONE 3-state enable output
-             );
--- End of STARTUPE2_inst instantiation
+  -- Measure FPGA die temperature.
+  fpgatemp0 : entity work.fpgatemp
+    generic map(DELAY_CYCLES => 480)
+    port map(
+      rst  => '0',
+      clk  => cpuclock,
+      temp => fpga_temperature);
 
+  -- Convert 20-bit audio @ 12.288 MHz to 16-bit audio @ 12.288 MHz.
+  AUDIO_TONE : entity work.audio_out_test_tone
+    generic map(
+      -- You have to update audio_clock if you change this
+      fref => 50.0
+    )
+    port map(
+      select_44100        => '0',
+      ref_rst             => dvi_reset,
+      ref_clk             => clk_in,
+      pcm_rst             => pcm_rst,
+      pcm_clk             => pcm_clk,
+      pcm_clken           => pcm_clken,
+      audio_left_slow     => audio_left_slow,
+      audio_right_slow    => audio_right_slow,
+      sample_ready_toggle => sample_ready_toggle,
+      pcm_l               => pcm_l,
+      pcm_r               => pcm_r
+    );
 
-  -- New clocking setup, using more optimised selection of multipliers
-  -- and dividers, as well as the ability of some clock outputs to provide an
-  -- inverted clock for free.
-  -- Also, the 50 and 100MHz ethernet clocks are now independent of the other
-  -- clocks, so that Vivado shouldn't try to meet timing closure in the (already
-  -- protected) domain crossings used for those.
-  
-  d0: if true generate
+  -- Video (VGA) + audio (PCM) to HDMI converter.
+  hdmi0 : entity work.vga_to_hdmi
+    port map(
+      select_44100 => '0',
+      -- Disable HDMI-style audio if one (from portp bit 1)
+      dvi     => dvi_select,
+      vic     => std_logic_vector(to_unsigned(17, 8)), -- CEA/CTA VIC 17=576p50 PAL, 2 = 480p60 NTSC
+      aspect  => "01",                                 -- 01=4:3, 10=16:9
+      pix_rep => '0',                                  -- no pixel repetition
+      vs_pol  => '1',                                  -- 1=active high
+      hs_pol  => '1',
 
-    clocks1: entity work.clocking50mhz
-      port map ( clk_in    => CLK_IN,
-                 clock27   => clock27,    --   27 MHz
-                 clock41   => cpuclock,   --   40.5 MHz
-                 clock50   => ethclock,   --   50     MHz
-                 clock81p  => pixelclock, --   81  MHz
-                 clock81n  => clock81n,   --   81  MHz
-                 clock100  => clock100,   --  100     MHz
-                 clock135p => clock135p,  --  135 MHz
-                 clock135n => clock135n,  --  135 MHz inverted
-                 clock135n2 => clock135n2,  --  135 MHz inverted via another method
-                 clock162  => clock162,   -- 162    MHz
-                 clock324  => clock324    -- 324      MHz
-                 );
+      vga_rst => dvi_reset,       -- active high reset
+      vga_clk => clock27,         -- VGA pixel clock
+      vga_vs  => v_vsync,         -- active high vsync
+      vga_hs  => v_hdmi_hsync,    -- active high hsync
+      vga_de  => hdmi_dataenable, -- pixel enable
+      vga_r   => std_logic_vector(v_red),
+      vga_g   => std_logic_vector(v_green),
+      vga_b   => std_logic_vector(v_blue),
 
-    -- simple audio test tone
-    AUDIO_TONE: entity work.audio_out_test_tone
-      generic map (
-        -- You have to update audio_clock if you change this
-        fref        => 50.0
-        )
-        port map (
-            ref_rst   => reset_high,
-            ref_clk   => CLK_IN,
-            pcm_rst   => pcm_rst,
-            pcm_clk   => pcm_clk,
-            pcm_clken => pcm_clken,
+      -- Feed in audio
+      pcm_rst   => pcm_rst,   -- active high audio reset
+      pcm_clk   => pcm_clk,   -- audio clock at fs
+      pcm_clken => pcm_clken, -- audio clock enable
+      pcm_l     => pcm_l,
+      pcm_r     => pcm_r,
+      pcm_acr   => pcm_acr,                                  -- 1KHz
+      pcm_n     => std_logic_vector(to_unsigned(6144, 20)),  -- ACR N value
+      pcm_cts   => std_logic_vector(to_unsigned(27000, 20)), -- ACR CTS value
 
-            audio_left_slow => audio_left_slow,
-            audio_right_slow => audio_right_slow,
-            sample_ready_toggle => sample_ready_toggle,
-            
-            pcm_l     => pcm_l,
-            pcm_r     => pcm_r
-        );
+      tmds => tmds
+    );
 
-    pcm_n <= std_logic_vector(to_unsigned(6144,pcm_n'length));
-    pcm_cts <= std_logic_vector(to_unsigned(27000,pcm_cts'length));
-    
-    hdmi0: entity work.vga_to_hdmi
-      generic map (pcm_fs => 48.0 -- 48.0KHz audio
-                   )
-      port map (
-        dvi => '0',   -- Enable HDMI-style audio
-        vic => std_logic_vector(to_unsigned(17,8)), -- CEA/CTA VIC 17=576p50 PAL, 2 = 480p60 NTSC
-        aspect => "01", -- 01=4:3, 10=16:9
-        pix_rep => '0', -- no pixel repetition
-        vs_pol => '1',  -- 1=active high
-        hs_pol => '1',
+  -- High-speed serializer for HDMI clock.
+  HDMI_CLK : entity work.serialiser_10to1_selectio
+    port map(
+      clk_x10 => clock270,
+      d       => "0000011111",
+      out_p   => tmds_clk_p,
+      out_n   => tmds_clk_n
+    );
 
-        vga_rst => reset_high, -- active high reset
-        vga_clk => clock27, -- VGA pixel clock
-        vga_vs => v_vsync, -- active high vsync
-        vga_hs => v_vga_hsync, -- active high hsync
-        vga_de => hdmi_dataenable,   -- pixel enable
-        vga_r => std_logic_vector(v_red),
-        vga_g => std_logic_vector(v_green),
-        vga_b => std_logic_vector(v_blue),
+  -- High-speed serializers for HDMI data.
+  GEN_HDMI_DATA : for i in 0 to 2 generate
+  begin
+    HDMI_DATA : entity work.serialiser_10to1_selectio
+      port map(
+        clk_x10 => clock270,
+        d       => tmds(i),
+        out_p   => tmds_data_p(i),
+        out_n   => tmds_data_n(i)
+      );
+  end generate GEN_HDMI_DATA;
 
-        -- XXX For now the audio stuff is all dummy
-        pcm_rst => pcm_rst, -- active high audio reset
-        pcm_clk => pcm_clk, -- audio clock at fs
-        pcm_clken => pcm_clken, -- audio clock enable
-        pcm_l => pcm_l,
-        pcm_r => pcm_r,
-        pcm_acr => pcm_acr, -- 1KHz
-        pcm_n => pcm_n, -- ACR N value
-        pcm_cts => pcm_cts, -- ACR CTS value
-
-        tmds => tmds
-        );
-    
-     -- serialiser: in this design we use TMDS SelectIO outputs
-    GEN_HDMI_DATA: for i in 0 to 2 generate
-    begin
-        HDMI_DATA: entity work.serialiser_10to1_selectio
-            port map (
-                rst     => reset_high,
-                clk     => clock27,
-                clk_x5  => clock135p,
-                d       => tmds(i),
-                out_p   => TMDS_data_p(i),
-                out_n   => TMDS_data_n(i)
-            );
-    end generate GEN_HDMI_DATA;
-    HDMI_CLK: entity work.serialiser_10to1_selectio
-        port map (
-            rst     => reset_high,
-            clk     => clock27,
-            clk_x5  => clock135p,
-            d       => "0000011111",
-            out_p   => TMDS_clk_p,
-            out_n   => TMDS_clk_n
-        );
-
-    
-    fpgatemp0: entity work.fpgatemp
-      generic map (DELAY_CYCLES => 480)
-      port map (
-        rst => '0',
-        clk => cpuclock,
-        temp => fpga_temperature);
-
-    kbd0: entity work.mega65kbd_to_matrix
-      port map (
-        cpuclock => cpuclock,
-        
-        disco_led_en => disco_led_en,
-        disco_led_id => disco_led_id,
-        disco_led_val => disco_led_val,
-        
-        powerled => '1',
-        flopled => flopled_drive,
-        flopmotor => flopmotor_drive,
-            
---      kio8 => kb_io0,
---      kio9 => kb_io1,
-        kio10 => '1', -- no keys pressed
-
-        matrix_col => widget_matrix_col,
-        matrix_col_idx => widget_matrix_col_idx,
-        restore => widget_restore,
-        fastkey_out => fastkey,
-        capslock_out => widget_capslock,
-        upkey => keyup,
-        leftkey => keyleft
-
-        );
-
-    slow_devices0: entity work.slow_devices
-      generic map (
-        target => wukong
-        )
-      port map (
-        cpuclock => cpuclock,
-        pixelclock => pixelclock,
-        reset => iec_reset_drive,
-        cpu_exrom => cpu_exrom,
-        cpu_game => cpu_game,
-        sector_buffer_mapped => sector_buffer_mapped,
-        
-        cart_nmi => '1',
-        cart_irq => '1',
-        cart_dma => '1',
-        
-        cart_exrom => cart_exrom,
-        cart_ba => cart_ba,
-        cart_rw => cart_rw,
-        cart_roml => cart_roml,
-        cart_romh => cart_romh,
-        cart_io1 => cart_io1,
-        cart_game => cart_game,
-        cart_io2 => cart_io2,
-        
-        cart_d_in => cart_d_read,
-        cart_d => cart_d,
-        cart_a => cart_a,
-        
-        irq_out => irq_out,
-        nmi_out => nmi_out,
-        
-        joya => joy3,
-        joyb => joy4,
-        
-        fm_left => fm_left,
-        fm_right => fm_right,
-        
---      cart_busy => led,
-        cart_access_count => cart_access_count,
-        
-        slow_access_request_toggle => slow_access_request_toggle,
-        slow_access_ready_toggle => slow_access_ready_toggle,
-        slow_access_write => slow_access_write,
-        slow_access_address => slow_access_address,
-        slow_access_wdata => slow_access_wdata,
-        slow_access_rdata => slow_access_rdata,
-        
-        slow_prefetched_address => slow_prefetched_address,
-        slow_prefetched_data => slow_prefetched_data,
-        slow_prefetched_request_toggle => slow_prefetched_request_toggle,
-        
-        ----------------------------------------------------------------------
-        -- Expansion RAM interface (upto 127MB)
-        ----------------------------------------------------------------------
-        expansionram_busy => '1',
-        expansionram_data_ready_strobe => '1'
-        
-        );
-  end generate;
-    
-  red_s_n <= red_s;
-  green_s_n <= green_s;
-  blue_s_n <= blue_s;
-  
-  debug(0) <= clock27;
-  debug(1) <= cpuclock;
-  debug(2) <= clock135n2;
-  debug(3) <= clock135p;
-  debug(4) <= clock135n;
-
-  
-  pd0: if false generate
-    pixeldriver0: entity work.pixel_driver port map (
-      cpuclock => cpuclock,
-      clock81 => pixelclock,
-      clock27 => clock27,
-      
-      pal50_select => KEY1,
-      vga60_select => '0',
-      test_pattern_enable => '1',
-      hsync_invert => '0',
-      vsync_invert => '0',
-      narrow_dataenable => hdmi_dataenable,
-
-      red_i => to_unsigned(0,8),
-      green_i => to_unsigned(0,8),
-      blue_i => to_unsigned(0,8),
-
-      std_logic_vector(red_o) => v_red,
-      std_logic_vector(green_o) => v_green,
-      std_logic_vector(blue_o) => v_blue,
-      vga_hsync => v_vga_hsync,
-      vsync => v_vsync,
-      vga_blank   => vga_blank
-
-  );
-
-  end generate;
-  
-  m0: if true generate
-  machine0: entity work.machine
-    generic map (cpu_frequency => 40500000,
-                 target => wukong,
-                 hyper_installed => true -- For VIC-IV to know it can use
-                                         -- hyperram for full-colour glyphs
-                 )                 
-    port map (
-      pixelclock      => pixelclock,
-      cpuclock        => cpuclock,
-      uartclock       => cpuclock, -- Match CPU clock
-      clock162 => clock162,
-      clock100 => clock100,
-      clock27 => clock27,
-      clock50mhz      => ethclock,
-
---      hyper_addr => hyper_addr,
---      hyper_request_toggle => hyper_request_toggle,
-      hyper_data => (others => 'Z'),
-      hyper_data_strobe => '1',
-      
-      fast_key => fastkey,
-      
-      btncpureset => btncpureset,
-      reset_out => reset_out,
-      irq => irq_combined,
-      nmi => nmi_combined,
-      restore_key => restore_key,
+  -- Slow device manager.
+  slow_devices0 : entity work.slow_devices
+    generic map(
+      target => wukong
+    )
+    port map(
+      cpuclock             => cpuclock,
+      pixelclock           => pixelclock,
+      reset                => reset_out,
       sector_buffer_mapped => sector_buffer_mapped,
 
+      -- Slow device bus.
+      slow_access_request_toggle => slow_access_request_toggle,
+      slow_access_ready_toggle   => slow_access_ready_toggle,
+      slow_access_write          => slow_access_write,
+      slow_access_address        => slow_access_address,
+      slow_access_wdata          => slow_access_wdata,
+      slow_access_rdata          => slow_access_rdata,
+
+      -- Expansion RAM interface (upto 127MB)
+      expansionram_data_ready_toggle => '1',
+      expansionram_busy              => '1',
+
+      -- Expansion / cartridge port.
+      cart_nmi   => 'Z',
+      cart_irq   => 'Z',
+      cart_dma   => 'Z',
+      cart_exrom => 'Z',
+      cart_ba    => cart_ba,
+      cart_rw    => cart_rw,
+      cart_roml  => cart_roml,
+      cart_romh  => cart_romh,
+      cart_io1   => cart_io1,
+      cart_game  => 'Z',
+      cart_io2   => cart_io2,
+      cart_d_in  => (others => 'Z'),
+      cart_a     => cart_a
+    );
+
+  -- MEGA65 main component.
+  machine0 : entity work.machine
+    generic map(
+      cpu_frequency   => 40500000,
+      target          => wukong,
+      hyper_installed => false
+    )
+    port map(
+      pixelclock           => pixelclock,
+      cpuclock             => cpuclock,
+      uartclock            => cpuclock,
+      clock162             => '0',
+      clock200             => '0',
+      clock27              => clock27,
+      clock50mhz           => '0',
+      no_hyppo             => '0',
+      kbd_datestamp        => (others => '0'),
+      kbd_commit           => (others => '0'),
+      btncpureset          => btncpureset,
+      reset_out            => reset_out,
+      irq                  => irq,
+      nmi                  => nmi,
+      restore_key          => restore_key,
+      cpu_exrom            => '1',
+      cpu_game             => '1',
+      sector_buffer_mapped => sector_buffer_mapped,
+      fpga_temperature     => fpga_temperature,
+
+      -- QSPI flash.
       qspi_clock => qspi_clock,
-      qspicsn => qspicsn,
-      qspidb => qspidb,
-      
-      joy3 => joy3,
-      joy4 => joy4,
+      qspicsn    => qspi_csn,
+      qspidb     => qspi_db_out,
+      qspidb_in  => qspi_db_in,
+      qspidb_oe  => qspi_db_oe,
 
-      fm_left => fm_left,
-      fm_right => fm_right,
-      
-      no_hyppo => '0',
+      -- Audio.
+      audio_left  => audio_left,
+      audio_right => audio_right,
 
-      vga_blank => vga_blank,
+      -- Video.
       vsync           => v_vsync,
-      vga_hsync       => v_vga_hsync,
+      hdmi_hsync      => v_hdmi_hsync,
       vgared          => v_red,
       vgagreen        => v_green,
       vgablue         => v_blue,
---      hdmi_sda        => hdmi_sda,
---      hdmi_scl        => hdmi_scl,
---      hpd_a           => hpd_a,
-      lcd_dataenable => lcd_dataenable,
-      hdmi_dataenable =>  hdmi_dataenable,
-      
-      ----------------------------------------------------------------------
-      -- CBM floppy  std_logic_vectorerial port
-      ----------------------------------------------------------------------
-      iec_clk_en => iec_clk_en_drive,
-      iec_data_en => iec_data_en_drive,
-      iec_data_o => iec_data_o_drive,
-      iec_reset => iec_reset_drive,
-      iec_clk_o => iec_clk_o_drive,
-      iec_data_external => iec_data_i_drive,
-      iec_clk_external => iec_clk_i_drive,
-      iec_atn_o => iec_atn_drive,
-      iec_bus_active => '0', -- No IEC port on this target
+      hdmi_dataenable => hdmi_dataenable,
 
---      buffereduart_rx => '1',
-      buffereduart_ringindicate => (others => '0'),
-
-      porta_pins => column(7 downto 0),
-      portb_pins => row(7 downto 0),
-      keyboard_column8 => column(8),
-      caps_lock_key => '1',
-      keyleft => keyleft,
-      keyup => keyup,
-
-      fa_fire => fa_fire_drive,
-      fa_up => fa_up_drive,
-      fa_left => fa_left_drive,
-      fa_down => fa_down_drive,
-      fa_right => fa_right_drive,
-
-      fb_fire => fb_fire_drive,
-      fb_up => fb_up_drive,
-      fb_left => fb_left_drive,
-      fb_down => fb_down_drive,
-      fb_right => fb_right_drive,
-
-      fa_potx => fa_potx,
-      fa_poty => fa_poty,
-      fb_potx => fb_potx,
-      fb_poty => fb_poty,
-      pot_drain => pot_drain,
-      pot_via_iec => pot_via_iec,
-
-      f_index => '1',
-      f_track0 => '1',
-      f_writeprotect => '1',
-      f_rdata => '1',
-      f_diskchanged => '1',
-
-      ---------------------------------------------------------------------------
-      -- IO lines to the ethernet controller
-      ---------------------------------------------------------------------------
-      eth_mdio => eth_mdio,
-      eth_mdc => eth_mdc,
-      eth_reset => eth_reset,
-      eth_rxd => eth_rxd,
-      eth_txd => eth_txd,
-      eth_txen => eth_txen,
-      eth_rxer => eth_rxer,
-      eth_rxdv => eth_rxdv,
-      eth_interrupt => '0',
-      
-      -------------------------------------------------------------------------
-      -- Lines for the SDcard interfaces
-      -------------------------------------------------------------------------
-      -- External one is bus 0, so that it has priority.
-      -- Internal SD card:
-      cs_bo => sdReset,
-      sclk_o => sdClock,
-      mosi_o => sdMOSI,
-      miso_i => sdMISO,
-      -- External microSD
-      cs2_bo => sd2reset,
-      sclk2_o => sd2Clock,
-      mosi2_o => sd2MOSI,
-      miso2_i => sd2MISO,
-
+      -- Slow device bus.
       slow_access_request_toggle => slow_access_request_toggle,
-      slow_access_ready_toggle => slow_access_ready_toggle,
-      slow_access_address => slow_access_address,
-      slow_access_write => slow_access_write,
-      slow_access_wdata => slow_access_wdata,
-      slow_access_rdata => slow_access_rdata,
+      slow_access_ready_toggle   => slow_access_ready_toggle,
+      slow_access_address        => slow_access_address,
+      slow_access_write          => slow_access_write,
+      slow_access_wdata          => slow_access_wdata,
+      slow_access_rdata          => slow_access_rdata,
 
-      slow_prefetched_address => slow_prefetched_address,
-      slow_prefetched_data => slow_prefetched_data,
-      slow_prefetched_request_toggle => slow_prefetched_request_toggle,
-      
-      cpu_exrom => cpu_exrom,      
-      cpu_game => cpu_game,
-      cart_access_count => cart_access_count,
+      -- CIA1 ports (physical keyboard and joysticks).
+      porta_pins    => porta_pins,
+      portb_pins    => portb_pins,
+      caps_lock_key => '1',
+      keyleft       => '0',
+      keyup         => '0',
+      fa_fire       => fa_fire ,
+      fa_up         => fa_up   ,
+      fa_left       => fa_left ,
+      fa_down       => fa_down ,
+      fa_right      => fa_right,
+      fb_fire       => fb_fire ,
+      fb_up         => fb_up   ,
+      fb_left       => fb_left ,
+      fb_down       => fb_down ,
+      fb_right      => fb_right,
+      fa_potx       => '0',
+      fa_poty       => '0',
+      fb_potx       => '0',
+      fb_poty       => '0',
 
---      aclMISO => aclMISO,
+      -- Internal SD card (bus #1).
+      cs_bo  => int_sd_reset,
+      sclk_o => int_sd_clock,
+      mosi_o => int_sd_mosi,
+      miso_i => int_sd_miso,
+
+      -- Serial monitor.
+      UART_TXD => uart_txd,
+      RsRx     => rsrx,
+
+      -- SYSCTL configuration register.
+      portp_out => portp,
+
+      -- Switches and buttons.
+      sw    => (others => '0'),
+      dipsw => (others => '0'),
+      btn   => (others => '1'),
+
+      --------------------------------------------------------------------------
+      -- Unsupported components and peripherals.
+      --------------------------------------------------------------------------
+
+      -- CBM floppy serial port (not supported).
+      iec_data_external => '1',
+      iec_clk_external  => '1',
+      iec_srq_external  => '1',
+      iec_bus_active    => '0',
+
+      -- External SD card (bus #0, priority) (not supported).
+      miso2_i => '1',
+
+      -- Floppy drive interface (not supported).
+      f_index        => '1',
+      f_track0       => '1',
+      f_writeprotect => '1',
+      f_rdata        => '1',
+      f_diskchanged  => '1',
+
+      -- Ethernet controller (not supported).
+      eth_rxd       => "00",
+      eth_rxer      => '0',
+      eth_rxdv      => '0',
+      eth_interrupt => '0',
+
+      -- Accelerometer (not supported).
       aclMISO => '1',
---      aclMOSI => aclMOSI,
---      aclSS => aclSS,
---      aclSCK => aclSCK,
---      aclInt1 => aclInt1,
---      aclInt2 => aclInt2,
       aclInt1 => '1',
       aclInt2 => '1',
-    
+
+      -- Temperature sensor / I2C bus #0 (not supported).
+      tmpint => '1',
+      tmpct  => '1',
+
+      -- Microphones (not supported).
       micData0 => '1',
       micData1 => '1',
---      micClk => micClk,
---      micLRSel => micLRSel,
 
-      disco_led_en => disco_led_en,
-      disco_led_id => disco_led_id,
-      disco_led_val => disco_led_val,      
-      
-      flopled => flopled_drive,
-      flopmotor => flopmotor_drive,
-      ampPWM_l => pwm_l_drive,
-      ampPWM_r => pwm_r_drive,
-      ampSD => pcspeaker_muten,
-      pcspeaker_left => pcspeaker_left_drive,
-      audio_left => audio_left,
-      audio_right => audio_right,
+      -- Buffered UART (not supported).
+      buffereduart_ringindicate => (others => '0'),
 
-      -- Normal connection of I2C peripherals to dedicated address space
-      i2c1sda => fpga_sda,
-      i2c1scl => fpga_scl,
+      -- PS/2 keyboard (not supported).
+      ps2data  => '1',
+      ps2clock => '1',
 
---      tmpsda => fpga_sda,
---      tmpscl => fpga_scl,
+      -- Widget board / MEGA65R2 keyboard (not supported).
+      widget_matrix_col => (others => '1'),
+      widget_restore    => '1',
+      widget_capslock   => '1',
+      widget_joya       => (others => '1'),
+      widget_joyb       => (others => '1')
+    );
 
-      portp_out => portp,
-      
-      -- No PS/2 keyboard for now
-      ps2data =>      '1',
-      ps2clock =>     '1',
-
-      fpga_temperature => fpga_temperature,
-      
-      UART_TXD => UART_TXD,
-      RsRx => RsRx,
-
-      -- Ignore widget board interface and other things
-      tmpint => '1',
-      tmpct => '1',
-
-      -- Connect MEGA65 smart keyboard via JTAG-like remote GPIO interface
-      widget_matrix_col_idx => widget_matrix_col_idx,
-      widget_matrix_col => widget_matrix_col,
-      widget_restore => widget_restore,
-      widget_capslock => widget_capslock,
-      widget_joya => (others => '1'),
-      widget_joyb => (others => '1'),      
-      
-      sw => (others => '0'),
---      uart_rx => '1',
-      btn => (others => '1')
-
-      );
-  end generate;
-
-  process (pixelclock,cpuclock) is
+  -- Generate a 1 KHz ACR pulse train from 12.288 MHz.
+  process (pcm_clk) is
   begin
-    vdac_sync_n <= '0';  -- no sync on green
-    vdac_blank_n <= '1'; -- was: not (v_hsync or v_vsync);
+    if rising_edge(pcm_clk) then
+      if acr_counter /= (12288 - 1) then
+        acr_counter <= acr_counter + 1;
+        pcm_acr     <= '0';
+      else
+        pcm_acr     <= '1';
+        acr_counter <= 0;
+      end if;
+    end if;
+  end process;
 
-    -- VGA output at full pixel clock
-    vdac_clk <= pixelclock;
-
-    -- HDMI output at 27MHz
---    hdmi_clk <= clock27;
-
-    -- Ethernet clock at 50MHz
-    eth_clock <= ethclock;
-
-    -- Use both real and cartridge IRQ and NMI signals
-    irq_combined <= irq and irq_out;
-    nmi_combined <= nmi and nmi_out;
-    
+  -- Various processing steps synchronized to the CPU clock.
+  process (cpuclock) is
+  begin
     -- Drive most ports, to relax timing
     if rising_edge(cpuclock) then
+      -- @IO:GS $D61A.7 SYSCTL:AUDINV Invert digital video audio sample values
+      -- @IO:GS $D61A.4 SYSCTL:LED Control LED next to U1 on mother board
+      -- @IO:GS $D61A.3 SYSCTL:AUD48K Select 48KHz or 44.1KHz digital video audio sample rate
+      -- @IO:GS $D61A.2 SYSCTL:AUDDBG Visualise audio samples (DEBUG)
+      -- @IO:GS $D61A.1 SYSCTL:DVI Control digital video as DVI (disables audio)
+      -- @IO:GS $D61A.0 SYSCTL:AUDMUTE Mute digital video audio (MEGA65 R2 only)
+      portp_drive <= portp;
+      dvi_select  <= portp_drive(1);
 
-      reset_high <= not btncpureset;
-      
-      -- We need to pass audio to 12.288 MHz clock domain.
-      -- Easiest way is to hold samples constant for 16 ticks, and
-      -- have a slow toggle
-      if audio_counter /= to_integer(audio_counter_interval) then
-        audio_counter <= audio_counter + 1;
+      -- The reset_button signal is active low, btncpureset is active low.
+      btncpureset <= reset_button;
+
+      -- Provide and clear single reset impulse to digital video output modules.
+      if reset_button = '1' then
+        dvi_reset <= '0';
+      end if;
+
+      -- We need to pass audio to 12.288 MHz clock domain. Easiest way is to
+      -- hold samples constant for 16 ticks, and have a slow toggle. At 40.5MHz
+      -- and 48KHz sample rate, we have a ratio of 843.75 Thus we need to
+      -- calculate the remainder, so that we can get the sample rate EXACTLY
+      -- 48KHz. Otherwise we end up using 844, which gives a sample rate of
+      -- 40.5MHz / 844 = 47.986KHz, which might just be enough to throw some
+      -- monitors out, since it means that the CTS / N rates will be wrong.
+      -- (Or am I just chasing my tail, because this is only used to set the
+      -- rate at which we LATCH the samples?)
+      if audio_counter < to_integer(audio_counter_interval) then
+        audio_counter <= audio_counter + 4;
       else
-        audio_counter <= 0;
+        audio_counter       <= audio_counter - to_integer(audio_counter_interval);
         sample_ready_toggle <= not sample_ready_toggle;
-        audio_left_slow <= h_audio_left;
-        audio_right_slow <= h_audio_right;
+        audio_left_slow     <= h_audio_left;
+        audio_right_slow    <= h_audio_right;
       end if;
-      
-      segled_counter <= segled_counter + 1;
-      led2 <= segled_counter(22);
-      
---      led <= cart_exrom;
---      led <= flopled_drive;
-      
-      fa_left_drive <= fa_left;
-      fa_right_drive <= fa_right;
-      fa_up_drive <= fa_up;
-      fa_down_drive <= fa_down;
-      fa_fire_drive <= fa_fire;  
-      fb_left_drive <= fb_left;
-      fb_right_drive <= fb_right;
-      fb_up_drive <= fb_up;
-      fb_down_drive <= fb_down;
-      fb_fire_drive <= fb_fire;  
-
-      -- The CIAs drive these lines naively, so we need to apply the inverters
-      -- on the outputs here, and also deal with the particulars of how the
-      -- MEGA65 PCB drives these lines.
-      -- Note that the MEGA65 PCB lacks pull-ups on these lines, and relies on
-      -- the connected disk drive(s) having pull-ups of their own.
-      -- Here is the truth table for behaviour with a pull-up on the pin:
-      -- +----+-----++----+
-      -- | _o | _en || _i |
-      -- +----+-----++----+
-      -- |  0 |   X || 0  |
-      -- |  1 |   0 || 1* |
-      -- |  1 |   1 || 1  |
-      -- +----+-----++----+
-      -- * Value provided by pin up, or equivalently device on the bus
-      --
-      -- End result is simple: Invert output bit, and copy output enable
-      -- Except, that the CIA always thinks it is driving the line, so
-      -- we need to ignore the _en lines, and instead use the _o lines
-      -- (before inversion) to indicate when we should be driving the pin
-      -- to ground.
-
-      iec_reset <= iec_reset_drive;
-      iec_atn <= not iec_atn_drive;
-
-      if pot_via_iec = '0' then
-        -- Normal IEC port operation
-        iec_clk_en <= iec_clk_o_drive;
-        iec_clk_o <= not iec_clk_o_drive;
-        iec_clk_i_drive <= iec_clk_i;
-        iec_data_en <= iec_data_o_drive;
-        iec_data_o <= not iec_data_o_drive;
-        iec_data_i_drive <= iec_data_i;
-        -- So pots act like infinite resistance
-        fa_potx <= '0';
-        fa_poty <= '0';
-        fb_potx <= '0';
-        fb_poty <= '0';
-      else
-        -- IEC lines being used as POT inputs
-        iec_clk_i_drive <= '1';
-        iec_data_i_drive <= '1';
-        if pot_drain = '1' then
-          -- IEC lines being used to drain pots
-          iec_clk_en <= '1';
-          iec_clk_o <= '0';
-          iec_data_en <= '1';
-          iec_data_o <= '0';
-        else
-          -- Stop draining
-          iec_clk_en <= '0';
-          iec_clk_o <= '0';
-          iec_data_en <= '0';
-          iec_data_o <= '0';
-        end if;
-        -- Copy IEC input values to POT inputs
-        fa_potx <= iec_data_i;
-        fa_poty <= iec_clk_i;
-        fb_potx <= iec_data_i;
-        fb_poty <= iec_clk_i;
-      end if;
-
---      pwm_l <= pwm_l_drive;
---      pwm_r <= pwm_r_drive;
---      pcspeaker_left <= pcspeaker_left_drive;
-      
     end if;
+  end process;
 
-    h_audio_right <= audio_right;
-    h_audio_right <= audio_left;
-    -- toggle signed/unsigned audio flipping
-    if portp(7)='1' then
-      h_audio_right(19) <= not audio_right(19);
-      h_audio_left(19) <= not audio_left(19);
-    end if;
+  -- Handle data direction on the QSPI flash data pins.
+  qspi_db    <= qspi_db_out when qspi_db_oe = '1' else "ZZZZ";
+  qspi_db_in <= qspi_db;
 
+  -- Invert audio sign bit if requested.
+  h_audio_right <= audio_right when portp_drive(7) = '0' else ((not audio_right(19)) & audio_right(18 downto 0));
+  h_audio_left  <= audio_left  when portp_drive(7) = '0' else ((not audio_left (19)) & audio_left (18 downto 0));
 
-    
-    
-    if portp(3)='1' then
-      hdmi_is_progressive <= true;
-    else
-      hdmi_is_progressive <= false;
-    end if;
-    if portp(4)='1' then
-      hdmi_is_pal <= true;
-    else
-      hdmi_is_pal <= false;
-    end if;
-    if portp(5)='1' then
-      hdmi_is_30khz <= true;
-    else
-      hdmi_is_30khz <= false;
-    end if;
-    if portp(6)='1' then
-      hdmi_is_limited <= true;
-    else
-      hdmi_is_limited <= false;
-    end if;
-    if portp(7)='1' then
-      hdmi_is_widescreen <= true;
-    else
-      hdmi_is_widescreen <= false;
-    end if;
-    
+  -- LED on main board (active low).
+  led <= not portp_drive(4);
 
-    
-    if rising_edge(pixelclock) then
-      hsync <= v_vga_hsync;
-      vsync <= v_vsync;
-      vgared <= v_red;
-      vgagreen <= v_green;
-      vgablue <= v_blue;
-      hdmired <= v_red;
-      hdmigreen <= v_green;
-      hdmiblue <= v_blue;
-    end if;
-
-    -- XXX DEBUG: Allow showing audio samples on video to make sure they are
-    -- getting through
---    if portp(2)='1' then
---      vgagreen <= unsigned(audio_left(15 downto 8));
---      vgared <= unsigned(audio_right(15 downto 8));
---      hdmigreen <= unsigned(audio_left(15 downto 8));
---      hdmired <= unsigned(audio_right(15 downto 8));
---    end if;
-    
-  end process;    
-  
 end Behavioral;

--- a/src/vhdl/wukong.vhdl
+++ b/src/vhdl/wukong.vhdl
@@ -52,6 +52,8 @@ entity container is
 --         kb_io0 : out std_logic;
 --         kb_io1 : out std_logic;
 --         kb_io2 : in std_logic;
+         porta_pins : inout std_logic_vector(7 downto 0);
+         portb_pins : inout std_logic_vector(7 downto 0);
 
          ---------------------------------------------------------------------------
          -- IO lines to QSPI config flash (used so that we can update bitstreams)
@@ -583,7 +585,7 @@ begin
         capslock_out => widget_capslock,
         upkey => keyup,
         leftkey => keyleft
-      
+
         );
 
     slow_devices0: entity work.slow_devices
@@ -892,14 +894,14 @@ begin
       sw => (others => '0'),
 --      uart_rx => '1',
       btn => (others => '1')
-         
+
       );
   end generate;
 
   process (pixelclock,cpuclock) is
   begin
     vdac_sync_n <= '0';  -- no sync on green
-    vdac_blank_n <= '1'; -- was: not (v_hsync or v_vsync); 
+    vdac_blank_n <= '1'; -- was: not (v_hsync or v_vsync);
 
     -- VGA output at full pixel clock
     vdac_clk <= pixelclock;

--- a/src/vhdl/wukong.xdc
+++ b/src/vhdl/wukong.xdc
@@ -1,170 +1,126 @@
-############## NET - IOSTANDARD ##################
-set_property CFGBVS VCCO [current_design]
-set_property CONFIG_VOLTAGE 3.3 [current_design]
-set_property BITSTREAM.CONFIG.UNUSEDPIN PULLUP [current_design]
-#############SPI Configurate Setting##################
-set_property BITSTREAM.CONFIG.SPI_BUSWIDTH 4 [current_design]
-set_property CONFIG_MODE SPIx4 [current_design]
-set_property BITSTREAM.CONFIG.CONFIGRATE 50 [current_design]
-############## clock and reset define##################
-set_property -dict {PACKAGE_PIN M22 IOSTANDARD LVCMOS33} [get_ports CLK_IN]
-create_clock -period 20.000 [get_ports CLK_IN]
+################################################################################
+# General configuration options.
+################################################################################
+set_property CFGBVS                         VCCO    [current_design];
+set_property CONFIG_VOLTAGE                 3.3     [current_design];
+set_property BITSTREAM.CONFIG.UNUSEDPIN     PULLUP  [current_design];
+set_property BITSTREAM.CONFIG.SPI_BUSWIDTH  4       [current_design];
+set_property CONFIG_MODE                    SPIx4   [current_design];
+set_property BITSTREAM.CONFIG.CONFIGRATE    50      [current_design];
 
-### XXX Why on earth do we need to do this, when CLK_IN on M22 is in fact a clock,
-### and the same idiom works for the MEGA65 R2 board?
-set_property CLOCK_DEDICATED_ROUTE FALSE [get_nets {CLK_IN_IBUF}]
+################################################################################
+# System clock.
+################################################################################
+set_property -dict {PACKAGE_PIN M21 IOSTANDARD LVCMOS33} [get_ports clk_in];
+create_clock -period 20.000 [get_ports clk_in];
 
+################################################################################
+# Clock and timing constraints.
+################################################################################
+create_generated_clock -name clock81p [get_pins clocks/mmcm_adv0/CLKOUT2]
+create_generated_clock -name clock41  [get_pins clocks/mmcm_adv0/CLKOUT3]
+create_generated_clock -name clock27  [get_pins clocks/mmcm_adv0/CLKOUT4]
+create_generated_clock -name clock270 [get_pins clocks/mmcm_adv0/CLKOUT6]
+create_generated_clock -name clock60  [get_pins AUDIO_TONE/CLOCK/MMCM/CLKOUT1]
 
-## Make Ethernet clocks unrelated to other clocks to avoid erroneous timing
-## violations, and hopefully make everything synthesise faster.
-set_clock_groups -asynchronous \
-     -group { cpuclock hdmi_clk_OBUF vdac_clk_OBUF clock162 clock325 } \
-     -group { CLKFBOUT clk_fb_eth clock100 clock200 eth_clock_OBUF } \
+# Fix 12.288MHz clock generation clock domain crossing.
+set_false_path -from [get_clocks clock41] -to [get_clocks clock60]
 
-# Deal with more false paths crossing ethernet / cpu clock domains
-set_false_path -from [get_clocks cpuclock] -to [get_clocks ethclock]
-set_false_path -from [get_clocks ethclock] -to [get_clocks cpuclock]
+################################################################################
+# QSPI flash
+################################################################################
+set_property -dict {PACKAGE_PIN R14 IOSTANDARD LVCMOS33 PULLTYPE PULLUP} [get_ports {qspi_db[0]}];
+set_property -dict {PACKAGE_PIN R15 IOSTANDARD LVCMOS33 PULLTYPE PULLUP} [get_ports {qspi_db[1]}];
+set_property -dict {PACKAGE_PIN P14 IOSTANDARD LVCMOS33 PULLTYPE PULLUP} [get_ports {qspi_db[2]}];
+set_property -dict {PACKAGE_PIN N14 IOSTANDARD LVCMOS33 PULLTYPE PULLUP} [get_ports {qspi_db[3]}];
+set_property -dict {PACKAGE_PIN P18 IOSTANDARD LVCMOS33                } [get_ports qspi_csn    ];
 
-### XXX And for that matter, why do we need this, when it syntheses fine on the
-### MEGA65 R2 board which also has an 100T part, with the same number of clocking
-### resources.
+################################################################################
+# Buttons.
+################################################################################
+set_property -dict {PACKAGE_PIN H7  IOSTANDARD LVCMOS33} [get_ports reset_button];
+#set_property -dict {PACKAGE_PIN M6  IOSTANDARD LVCMOS33} [get_ports button2     ];
 
-################ QSPI Flash ###############################3
-set_property  -dict { PACKAGE_PIN R14 IOSTANDARD LVCMOS33 } [get_ports {QspiDB[0]}]
-set_property  -dict { PACKAGE_PIN R15 IOSTANDARD LVCMOS33 } [get_ports {QspiDB[1]}]
-set_property  -dict { PACKAGE_PIN P14 IOSTANDARD LVCMOS33 } [get_ports {QspiDB[2]}]
-set_property  -dict { PACKAGE_PIN N14 IOSTANDARD LVCMOS33 } [get_ports {QspiDB[3]}]
-set_property  -dict { PACKAGE_PIN P18 IOSTANDARD LVCMOS33 } [get_ports QspiCSn]
-set_property PULLUP true [get_ports {qspidb[0]}]
-set_property PULLUP true [get_ports {qspidb[1]}]
-set_property PULLUP true [get_ports {qspidb[2]}]
-set_property PULLUP true [get_ports {qspidb[3]}]
+################################################################################
+# LEDs.
+################################################################################
+set_property -dict {PACKAGE_PIN V17 IOSTANDARD LVCMOS33} [get_ports led         ];
+#set_property -dict {PACKAGE_PIN V16 IOSTANDARD LVCMOS33} [get_ports led2        ];
 
-############## Dummy VGA interface for debugging on J12 ##################
-set_property -dict {PACKAGE_PIN AB26 IOSTANDARD LVCMOS33} [get_ports vdac_clk]
-set_property -dict {PACKAGE_PIN AB24 IOSTANDARD LVCMOS33} [get_ports vdac_sync_n]
-set_property -dict {PACKAGE_PIN AA24 IOSTANDARD LVCMOS33} [get_ports vdac_blank_n]
+################################################################################
+# Internal SD-card interface.
+################################################################################
+set_property -dict {PACKAGE_PIN J8 IOSTANDARD LVCMOS33} [get_ports int_sd_mosi ];
+set_property -dict {PACKAGE_PIN L4 IOSTANDARD LVCMOS33} [get_ports int_sd_clock];
+set_property -dict {PACKAGE_PIN J6 IOSTANDARD LVCMOS33} [get_ports int_sd_reset];
+set_property -dict {PACKAGE_PIN M5 IOSTANDARD LVCMOS33} [get_ports int_sd_miso ];
 
-#
-set_property -dict {PACKAGE_PIN AA22 IOSTANDARD LVCMOS33} [get_ports {vgared[0]}]
-set_property -dict {PACKAGE_PIN Y25 IOSTANDARD LVCMOS33} [get_ports {vgared[1]}]
-set_property -dict {PACKAGE_PIN W25 IOSTANDARD LVCMOS33} [get_ports {vgared[2]}]
-set_property -dict {PACKAGE_PIN Y22 IOSTANDARD LVCMOS33} [get_ports {vgared[3]}]
-set_property -dict {PACKAGE_PIN W21 IOSTANDARD LVCMOS33} [get_ports {vgared[4]}]
-set_property -dict {PACKAGE_PIN V26 IOSTANDARD LVCMOS33} [get_ports {vgared[5]}]
-set_property -dict {PACKAGE_PIN U25 IOSTANDARD LVCMOS33} [get_ports {vgared[6]}]
-set_property -dict {PACKAGE_PIN V24 IOSTANDARD LVCMOS33} [get_ports {vgared[7]}]
+################################################################################
+# External SD-card interface.
+################################################################################
+#set_property -dict {PACKAGE_PIN J8 IOSTANDARD LVCMOS33} [get_ports ext_sd_mosi ];
+#set_property -dict {PACKAGE_PIN L4 IOSTANDARD LVCMOS33} [get_ports ext_sd_clock];
+#set_property -dict {PACKAGE_PIN J6 IOSTANDARD LVCMOS33} [get_ports ext_sd_reset];
+#set_property -dict {PACKAGE_PIN M5 IOSTANDARD LVCMOS33} [get_ports ext_sd_miso ];
 
-set_property -dict {PACKAGE_PIN V23 IOSTANDARD LVCMOS33} [get_ports {vgagreen[0]}]
-set_property -dict {PACKAGE_PIN V18 IOSTANDARD LVCMOS33} [get_ports {vgagreen[1]}]
-set_property -dict {PACKAGE_PIN U22 IOSTANDARD LVCMOS33} [get_ports {vgagreen[2]}]
-set_property -dict {PACKAGE_PIN U21 IOSTANDARD LVCMOS33} [get_ports {vgagreen[3]}]
-set_property -dict {PACKAGE_PIN T20 IOSTANDARD LVCMOS33} [get_ports {vgagreen[4]}]
-set_property -dict {PACKAGE_PIN T19 IOSTANDARD LVCMOS33} [get_ports {vgagreen[5]}]
-set_property -dict {PACKAGE_PIN AC26 IOSTANDARD LVCMOS33} [get_ports {vgagreen[6]}]
-set_property -dict {PACKAGE_PIN AC24 IOSTANDARD LVCMOS33} [get_ports {vgagreen[7]}]
+################################################################################
+# USB serial interface.
+################################################################################
+set_property -dict {PACKAGE_PIN E3 IOSTANDARD LVCMOS33} [get_ports uart_txd];
+set_property -dict {PACKAGE_PIN F3 IOSTANDARD LVCMOS33} [get_ports rsrx    ];
 
-set_property -dict {PACKAGE_PIN AB25 IOSTANDARD LVCMOS33} [get_ports {vgablue[0]}]
-set_property -dict {PACKAGE_PIN AA23 IOSTANDARD LVCMOS33} [get_ports {vgablue[1]}]
-set_property -dict {PACKAGE_PIN AA25 IOSTANDARD LVCMOS33} [get_ports {vgablue[2]}]
-set_property -dict {PACKAGE_PIN Y26 IOSTANDARD LVCMOS33} [get_ports {vgablue[3]}]
-set_property -dict {PACKAGE_PIN Y23 IOSTANDARD LVCMOS33} [get_ports {vgablue[4]}]
-set_property -dict {PACKAGE_PIN Y21 IOSTANDARD LVCMOS33} [get_ports {vgablue[5]}]
-set_property -dict {PACKAGE_PIN W26 IOSTANDARD LVCMOS33} [get_ports {vgablue[6]}]
-set_property -dict {PACKAGE_PIN U26 IOSTANDARD LVCMOS33} [get_ports {vgablue[7]}]
+################################################################################
+# HDMI interface.
+################################################################################
+set_property -dict {PACKAGE_PIN C4 IOSTANDARD TMDS_33} [get_ports tmds_clk_n      ];
+set_property -dict {PACKAGE_PIN D4 IOSTANDARD TMDS_33} [get_ports tmds_clk_p      ];
+set_property -dict {PACKAGE_PIN D1 IOSTANDARD TMDS_33} [get_ports {tmds_data_n[0]}];
+set_property -dict {PACKAGE_PIN E1 IOSTANDARD TMDS_33} [get_ports {tmds_data_p[0]}];
+set_property -dict {PACKAGE_PIN E2 IOSTANDARD TMDS_33} [get_ports {tmds_data_n[1]}];
+set_property -dict {PACKAGE_PIN F2 IOSTANDARD TMDS_33} [get_ports {tmds_data_p[1]}];
+set_property -dict {PACKAGE_PIN G1 IOSTANDARD TMDS_33} [get_ports {tmds_data_n[2]}];
+set_property -dict {PACKAGE_PIN G2 IOSTANDARD TMDS_33} [get_ports {tmds_data_p[2]}];
 
-set_property -dict {PACKAGE_PIN W24 IOSTANDARD LVCMOS33} [get_ports {debug[0]}]
-set_property -dict {PACKAGE_PIN W23 IOSTANDARD LVCMOS33} [get_ports {debug[1]}]
-set_property -dict {PACKAGE_PIN W18 IOSTANDARD LVCMOS33} [get_ports {debug[2]}]
-set_property -dict {PACKAGE_PIN V22 IOSTANDARD LVCMOS33} [get_ports {debug[3]}]
-set_property -dict {PACKAGE_PIN V21 IOSTANDARD LVCMOS33} [get_ports {debug[4]}]
+################################################################################
+# C64 keyboard interface on J12.
+################################################################################
+set_property -dict {PACKAGE_PIN AB26 IOSTANDARD LVCMOS33 PULLTYPE PULLUP} [get_ports {portb_pins[3]}]; # J12:3  | IO_L3P_T0_DQS_13
+set_property -dict {PACKAGE_PIN AB24 IOSTANDARD LVCMOS33 PULLTYPE PULLUP} [get_ports {portb_pins[6]}]; # J12:5  | IO_L9P_T1_DQS_13
+set_property -dict {PACKAGE_PIN AA24 IOSTANDARD LVCMOS33 PULLTYPE PULLUP} [get_ports {portb_pins[5]}]; # J12:7  | IO_L7P_T1_13
+set_property -dict {PACKAGE_PIN AA22 IOSTANDARD LVCMOS33 PULLTYPE PULLUP} [get_ports {portb_pins[4]}]; # J12:9  | IO_L8P_T1_13
+set_property -dict {PACKAGE_PIN Y25  IOSTANDARD LVCMOS33 PULLTYPE PULLUP} [get_ports {portb_pins[7]}]; # J12:11 | IO_L5P_T0_13
+set_property -dict {PACKAGE_PIN W25  IOSTANDARD LVCMOS33 PULLTYPE PULLUP} [get_ports {portb_pins[2]}]; # J12:13 | IO_L4P_T0_13
+set_property -dict {PACKAGE_PIN Y22  IOSTANDARD LVCMOS33 PULLTYPE PULLUP} [get_ports {portb_pins[1]}]; # J12:15 | IO_L11P_T1_SRCC_13
+set_property -dict {PACKAGE_PIN W21  IOSTANDARD LVCMOS33 PULLTYPE PULLUP} [get_ports {portb_pins[0]}]; # J12:17 | IO_L14P_T2_SRCC_13
+set_property -dict {PACKAGE_PIN V26  IOSTANDARD LVCMOS33 DRIVE 16       } [get_ports {porta_pins[0]}]; # J12:19 | IO_L2P_T0_13
+set_property -dict {PACKAGE_PIN U25  IOSTANDARD LVCMOS33 DRIVE 16       } [get_ports {porta_pins[6]}]; # J12:21 | IO_L1P_T0_13
+set_property -dict {PACKAGE_PIN V24  IOSTANDARD LVCMOS33 DRIVE 16       } [get_ports {porta_pins[5]}]; # J12:23 | IO_L6P_T0_13
+set_property -dict {PACKAGE_PIN V23  IOSTANDARD LVCMOS33 DRIVE 16       } [get_ports {porta_pins[4]}]; # J12:25 | IO_L10P_T1_13
+set_property -dict {PACKAGE_PIN V18  IOSTANDARD LVCMOS33 DRIVE 16       } [get_ports {porta_pins[3]}]; # J12:27 | IO_L19P_T3_13
+set_property -dict {PACKAGE_PIN U22  IOSTANDARD LVCMOS33 DRIVE 16       } [get_ports {porta_pins[2]}]; # J12:29 | IO_L12P_T1_MRCC_13
+set_property -dict {PACKAGE_PIN U21  IOSTANDARD LVCMOS33 DRIVE 16       } [get_ports {porta_pins[1]}]; # J12:31 | IO_L13P_T2_MRCC_13
+set_property -dict {PACKAGE_PIN T20  IOSTANDARD LVCMOS33 DRIVE 16       } [get_ports {porta_pins[7]}]; # J12:33 | IO_L15P_T2_DQS_13
 
-set_property -dict {PACKAGE_PIN U20 IOSTANDARD LVCMOS33} [get_ports hsync]
-set_property -dict {PACKAGE_PIN U19 IOSTANDARD LVCMOS33} [get_ports vsync]
+################################################################################
+# Control port 1 (PMOD) (J10).
+################################################################################
+set_property -dict {PACKAGE_PIN D5 IOSTANDARD LVCMOS33 PULLTYPE PULLUP} [get_ports fa_up   ]; # J10:1  | IO_L13N_T2_MRCC_35
+set_property -dict {PACKAGE_PIN G5 IOSTANDARD LVCMOS33 PULLTYPE PULLUP} [get_ports fa_left ]; # J10:2  | IO_L12P_T1_MRCC_35
+set_property -dict {PACKAGE_PIN E5 IOSTANDARD LVCMOS33 PULLTYPE PULLUP} [get_ports fa_down ]; # J10:7  | IO_L13P_T2_MRCC_35
+set_property -dict {PACKAGE_PIN E6 IOSTANDARD LVCMOS33 PULLTYPE PULLUP} [get_ports fa_right]; # J10:8  | IO_L1P_T0_AD4P_35
+set_property -dict {PACKAGE_PIN D6 IOSTANDARD LVCMOS33 PULLTYPE PULLUP} [get_ports fa_fire ]; # J10:9  | IO_L1N_T0_AD4N_35
+#set_property -dict {PACKAGE_PIN G7 IOSTANDARD LVCMOS33} [get_ports {pmod_j10[2]}]; # J10:3  | IO_L3N_T0_DQS_AD5N_35
+#set_property -dict {PACKAGE_PIN G8 IOSTANDARD LVCMOS33} [get_ports {pmod_j10[3]}]; # J10:4  | IO_L2N_T0_AD12N_35
+#set_property -dict {PACKAGE_PIN G6 IOSTANDARD LVCMOS33} [get_ports {pmod_j10[7]}]; # J10:10 | IO_L5N_T0_AD13N_35
 
-
-############## Switches and LEDs ##############
-set_property PACKAGE_PIN H7 [get_ports btnCpuReset]
-set_property IOSTANDARD LVCMOS33 [get_ports btnCpuReset]
-set_property PACKAGE_PIN J8 [get_ports KEY1]
-set_property IOSTANDARD LVCMOS33 [get_ports KEY1]
-set_property PACKAGE_PIN J6 [get_ports led]
-set_property IOSTANDARD LVCMOS33 [get_ports led]
-set_property PACKAGE_PIN H6 [get_ports led2]
-set_property IOSTANDARD LVCMOS33 [get_ports led2]
-
-############## SD Card Interface ##############
-### XXX PGS Pin assignments are almost surely wrong
-###         for the PMOD adapter we are using.
-set_property PACKAGE_PIN A5 [get_ports sdMOSI]
-set_property IOSTANDARD LVCMOS33 [get_ports sdMOSI]
-set_property PACKAGE_PIN F4 [get_ports sdClock]
-set_property IOSTANDARD LVCMOS33 [get_ports sdClock]
-set_property PACKAGE_PIN A4 [get_ports sdReset]
-set_property IOSTANDARD LVCMOS33 [get_ports sdReset]
-set_property PACKAGE_PIN H4 [get_ports sdMISO]
-set_property IOSTANDARD LVCMOS33 [get_ports sdMISO]
-
-set_property PACKAGE_PIN J4 [get_ports sd2MOSI]
-set_property IOSTANDARD LVCMOS33 [get_ports sd2MOSI]
-set_property PACKAGE_PIN G4 [get_ports sd2Clock]
-set_property IOSTANDARD LVCMOS33 [get_ports sd2Clock]
-set_property PACKAGE_PIN B4 [get_ports sd2Reset]
-set_property IOSTANDARD LVCMOS33 [get_ports sd2Reset]
-set_property PACKAGE_PIN B5 [get_ports sd2MISO]
-set_property IOSTANDARD LVCMOS33 [get_ports sd2MISO]
-
-
-############## USB Serial interface ###########
-set_property PACKAGE_PIN E3 [get_ports UART_TXD]
-set_property IOSTANDARD LVCMOS33 [get_ports UART_TXD]
-set_property PACKAGE_PIN F3 [get_ports RsRx]
-set_property IOSTANDARD LVCMOS33 [get_ports RsRx]
-
-
-############## HDMIOUT define##################
-set_property PACKAGE_PIN C4 [get_ports TMDS_clk_n]
-set_property IOSTANDARD TMDS_33 [get_ports TMDS_clk_n]
-set_property PACKAGE_PIN D4 [get_ports TMDS_clk_p]
-set_property IOSTANDARD TMDS_33 [get_ports TMDS_clk_p]
-
-set_property PACKAGE_PIN D1 [get_ports {TMDS_data_n[0]}]
-set_property IOSTANDARD TMDS_33 [get_ports {TMDS_data_n[0]}]
-set_property PACKAGE_PIN E1 [get_ports {TMDS_data_p[0]}]
-set_property IOSTANDARD TMDS_33 [get_ports {TMDS_data_p[0]}]
-
-set_property PACKAGE_PIN E2 [get_ports {TMDS_data_n[1]}]
-set_property IOSTANDARD TMDS_33 [get_ports {TMDS_data_n[1]}]
-set_property PACKAGE_PIN F2 [get_ports {TMDS_data_p[1]}]
-set_property IOSTANDARD TMDS_33 [get_ports {TMDS_data_p[1]}]
-
-set_property PACKAGE_PIN G1 [get_ports {TMDS_data_n[2]}]
-set_property IOSTANDARD TMDS_33 [get_ports {TMDS_data_n[2]}]
-set_property PACKAGE_PIN G2 [get_ports {TMDS_data_p[2]}]
-set_property IOSTANDARD TMDS_33 [get_ports {TMDS_data_p[2]}]
-
-set_false_path -from [get_pins machine0/iomapper0/block2.framepacker0/buffer_moby_toggle_reg/C] -to [get_pins {machine0/iomapper0/ethernet0/FS
-M_onehot_eth_tx_state_reg[3]/CE}]
-set_false_path -from [get_pins machine0/iomapper0/block2.framepacker0/buffer_moby_toggle_reg/C] -to [get_pins {machine0/iomapper0/ethernet0/FS
-M_onehot_eth_tx_state_reg[4]/CE}]
-set_false_path -from [get_pins machine0/iomapper0/block2.framepacker0/buffer_moby_toggle_reg/C] -to [get_pins {machine0/iomapper0/ethernet0/FS
-M_onehot_eth_tx_state_reg[5]/CE}]
-set_false_path -from [get_pins machine0/iomapper0/block2.framepacker0/buffer_moby_toggle_reg/C] -to [get_pins {machine0/iomapper0/ethernet0/FS
-M_onehot_eth_tx_state_reg[6]/CE}]
-set_false_path -from [get_pins machine0/iomapper0/block2.framepacker0/buffer_moby_toggle_reg/C] -to [get_pins {machine0/iomapper0/ethernet0/FSM_onehot_eth_tx_state_reg[7]/CE}]
-set_false_path -from [get_pins machine0/iomapper0/block2.framepacker0/buffer_moby_toggle_reg/C] -to [get_pins {machine0/iomapper0/ethernet0/FSM_onehot_eth_tx_state_reg[0]/CE}]
-set_false_path -from [get_pins machine0/iomapper0/block2.framepacker0/buffer_moby_toggle_reg/C] -to [get_pins {machine0/iomapper0/ethernet0/FSM_onehot_eth_tx_state_reg[1]/CE}]
-set_false_path -from [get_pins machine0/iomapper0/block2.framepacker0/buffer_moby_toggle_reg/C] -to [get_pins {machine0/iomapper0/ethernet0/FSM_onehot_eth_tx_state_reg[2]/CE}]
-set_false_path -from [get_pins machine0/iomapper0/block2.framepacker0/buffer_moby_toggle_reg/C] -to [get_pins {machine0/iomapper0/ethernet0/tx_preamble_count_reg[0]/S}]
-set_false_path -from [get_pins machine0/iomapper0/block2.framepacker0/buffer_moby_toggle_reg/C] -to [get_pins {machine0/iomapper0/ethernet0/tx_preamble_count_reg[2]/S}]
-
-set_false_path -from [get_pins machine0/iomapper0/block2.framepacker0/buffer_moby_toggle_reg/C] -to [get_pins {machine0/iomapper0/ethernet0/tx_preamble_count_reg[3]/S}]
-set_false_path -from [get_pins machine0/iomapper0/block2.framepacker0/buffer_moby_toggle_reg/C] -to [get_pins {machine0/iomapper0/ethernet0/tx_preamble_count_reg[4]/S}]
-set_false_path -from [get_pins machine0/iomapper0/block2.framepacker0/buffer_moby_toggle_reg/C] -to [get_pins {machine0/iomapper0/ethernet0/tx_preamble_count_reg[0]/CE}]
-set_false_path -from [get_pins machine0/iomapper0/block2.framepacker0/buffer_moby_toggle_reg/C] -to [get_pins {machine0/iomapper0/ethernet0/tx_preamble_count_reg[2]/CE}]
-set_false_path -from [get_pins machine0/iomapper0/block2.framepacker0/buffer_moby_toggle_reg/C] -to [get_pins machine0/iomapper0/ethernet0/eth_txen_int_reg/D]
-set_false_path -from [get_pins machine0/iomapper0/block2.framepacker0/buffer_moby_toggle_reg/C] -to [get_pins {machine0/iomapper0/ethernet0/tx_preamble_count_reg[3]/CE}]
-set_false_path -from [get_pins machine0/iomapper0/block2.framepacker0/buffer_moby_toggle_reg/C] -to [get_pins {machine0/iomapper0/ethernet0/tx_preamble_count_reg[4]/CE}]
-set_false_path -from [get_pins machine0/iomapper0/block2.framepacker0/buffer_moby_toggle_reg/C] -to [get_pins machine0/iomapper0/ethernet0/eth_tx_commenced_reg/D]
-set_max_delay -from [get_pins machine0/iomapper0/block2.framepacker0/buffer_moby_toggle_reg/C] -to [get_pins machine0/iomapper0/ethernet0/eth_tx_complete_reg/D] 0.000
-set_false_path -from [get_pins machine0/iomapper0/block2.framepacker0/buffer_moby_toggle_reg/C] -to [get_pins machine0/iomapper0/ethernet0/eth_tx_dump_reg/D]
+################################################################################
+# Control port 2 (PMOD) (J11).
+################################################################################
+set_property -dict {PACKAGE_PIN H4 IOSTANDARD LVCMOS33 PULLTYPE PULLUP} [get_ports fb_up   ]; # J11:1  | IO_L9N_T1_DQS_AD7N_35
+set_property -dict {PACKAGE_PIN F4 IOSTANDARD LVCMOS33 PULLTYPE PULLUP} [get_ports fb_left ]; # J11:2  | IO_L11N_T1_SRCC_35
+set_property -dict {PACKAGE_PIN J4 IOSTANDARD LVCMOS33 PULLTYPE PULLUP} [get_ports fb_down ]; # J11:7  | IO_L9P_T1_DQS_AD7P_35
+set_property -dict {PACKAGE_PIN G4 IOSTANDARD LVCMOS33 PULLTYPE PULLUP} [get_ports fb_right]; # J11:8  | IO_L11P_T1_SRCC_35
+set_property -dict {PACKAGE_PIN B4 IOSTANDARD LVCMOS33 PULLTYPE PULLUP} [get_ports fb_fire ]; # J11:9  | IO_L16P_T2_35
+#set_property -dict {PACKAGE_PIN A4 IOSTANDARD LVCMOS33} [get_ports {pmod_j11[2]}]; # J11:3  | IO_L16N_T2_35
+#set_property -dict {PACKAGE_PIN A5 IOSTANDARD LVCMOS33} [get_ports {pmod_j11[3]}]; # J11:4  | IO_L15N_T2_DQS_35
+#set_property -dict {PACKAGE_PIN B5 IOSTANDARD LVCMOS33} [get_ports {pmod_j11[7]}]; # J11:10 | IO_L15P_T2_DQS_35

--- a/vivado/wukong_gen.tcl
+++ b/vivado/wukong_gen.tcl
@@ -211,7 +211,7 @@ set files [list \
  "[file normalize "$origin_dir/src/vhdl/ddr_out_emard.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/keyboard_complex.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/virtual_to_matrix.vhdl"]"\
- "[file normalize "$origin_dir/src/vhdl/keyboard_to_matrix.vhdl"]"\
+ "[file normalize "$origin_dir/src/vhdl/keyboard_to_matrix_wukong.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/mega65kbd_to_matrix.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/matrix_to_ascii.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/widget_to_matrix.vhdl"]"\
@@ -422,7 +422,7 @@ set file "vhdl/keymapper.vhdl"
 set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
 set_property -name "file_type" -value "VHDL" -objects $file_obj
 
-set file "vhdl/keyboard_to_matrix.vhdl"
+set file "vhdl/keyboard_to_matrix_wukong.vhdl"
 set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
 set_property -name "file_type" -value "VHDL" -objects $file_obj
 

--- a/vivado/wukong_gen.tcl
+++ b/vivado/wukong_gen.tcl
@@ -94,7 +94,6 @@ set obj [get_filesets sources_1]
 # Import local files from the original project
 set files [list \
  "[file normalize "$origin_dir/src/vhdl/clocking50mhz.vhdl"]"\
- "[file normalize "$origin_dir/src/vhdl/clock50to100.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/reconfig.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/debugtools.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/cputypes.vhdl"]"\
@@ -106,10 +105,14 @@ set files [list \
  "[file normalize "$origin_dir/src/vhdl/sprite.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/pal_simulation.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/sid_voice.vhdl"]"\
+ "[file normalize "$origin_dir/src/vhdl/sid_tables.vhdl"]"\
+ "[file normalize "$origin_dir/src/verilog/sid_voice_8580.v"]"\
+ "[file normalize "$origin_dir/src/verilog/sid_envelope.v"]"\
  "[file normalize "$origin_dir/src/vhdl/sid_filters.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/sdcard.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/ghdl_videobuffer.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/ghdl_ram8x512.vhdl"]"\
+ "[file normalize "$origin_dir/src/vhdl/ghdl_ram8x2048.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/ghdl_ram8x4096.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/ghdl_ram8x4096_sync.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/ghdl_ram8x4096_sync_2cs.vhdl"]"\
@@ -125,11 +128,11 @@ set files [list \
  "[file normalize "$origin_dir/src/vhdl/bitplanes.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/vicii_sprites.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/UART_TX_CTRL.vhdl"]"\
- "[file normalize "$origin_dir/src/vhdl/uart_rx_buffered.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/uart_rx.vhdl"]"\
+ "[file normalize "$origin_dir/src/vhdl/uart_rx_buffered.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/buffereduart.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/sid_6581.vhdl"]"\
- "[file normalize "$origin_dir/src/vhdl/shadowram.vhdl"]"\
+ "[file normalize "$origin_dir/src/vhdl/shadowram-a100t.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/sdcardio.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/audio_mixer.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/audio_complex.vhdl"]"\
@@ -141,14 +144,21 @@ set files [list \
  "[file normalize "$origin_dir/src/vhdl/pcm_transceiver.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/touch.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/i2c_master.vhdl"]"\
+ "[file normalize "$origin_dir/src/vhdl/i2c_controller.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/i2c_wrapper.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/mega65r2_i2c.vhdl"]"\
+ "[file normalize "$origin_dir/src/vhdl/mega65r3_i2c.vhdl"]"\
+ "[file normalize "$origin_dir/src/vhdl/mega65r4_i2c.vhdl"]"\
+ "[file normalize "$origin_dir/src/vhdl/mega65r5_board_i2c.vhdl"]"\
+ "[file normalize "$origin_dir/src/vhdl/grove_i2c.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/mfm_bits_to_bytes.vhdl"]"\
+ "[file normalize "$origin_dir/src/vhdl/mfm_bits_to_gaps.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/mfm_decoder.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/mfm_gaps_to_bits.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/mfm_gaps.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/mfm_quantise_gaps.vhdl"]"\
- "[file normalize "$origin_dir/src/vhdl/rll27_bits_to_bytes.vhdl"]"\
+ "[file normalize "$origin_dir/src/vhdl/raw_bits_to_gaps.vhdl"]"\
+ "[file normalize "$origin_dir/src/vhdl/rll27_bits_to_gaps.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/rll27_gaps_to_bits.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/rll27_quantise_gaps.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/crc1581.vhdl"]"\
@@ -176,9 +186,13 @@ set files [list \
  "[file normalize "$origin_dir/src/vhdl/viciv.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/iomapper.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/gs4510.vhdl"]"\
+ "[file normalize "$origin_dir/src/vhdl/upscaler.vhdl"]"\
+ "[file normalize "$origin_dir/src/vhdl/r3_expansion.vhdl"]"\
+ "[file normalize "$origin_dir/src/vhdl/neotrng.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/fast_divide.vhdl"]"\
+ "[file normalize "$origin_dir/src/vhdl/sdram.vhdl"]"\
+ "[file normalize "$origin_dir/src/vhdl/sdram_controller.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/hyperram.vhdl"]"\
- "[file normalize "$origin_dir/src/vhdl/fakehyperram.vhdl"]"\
  "[file normalize "$origin_dir/src/verilog/hyper_xface.v"]"\
  "[file normalize "$origin_dir/src/vhdl/vfpga/overlay_IP.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/vfpga/vfpga_clock_controller_pausable.vhdl"]"\
@@ -199,16 +213,7 @@ set files [list \
  "[file normalize "$origin_dir/src/vhdl/uart_charrom.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/ddrwrapper.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/wukong.vhdl"]"\
- "[file normalize "$origin_dir/src/vhdl/dvid.vhdl"]"\
- "[file normalize "$origin_dir/src/vhdl/dvid_test.vhdl"]"\
- "[file normalize "$origin_dir/src/vhdl/aux_ecc1.vhdl"]"\
- "[file normalize "$origin_dir/src/vhdl/aux_ecc2.vhdl"]"\
- "[file normalize "$origin_dir/src/vhdl/aux_encoder.vhdl"]"\
- "[file normalize "$origin_dir/src/vhdl/edvi_ucode.vhdl"]"\
- "[file normalize "$origin_dir/src/vhdl/infoframe_rom_800x600_60hz_40M_48k.vhdl"]"\
- "[file normalize "$origin_dir/src/vhdl/TMDS_encoder.vhdl"]"\
- "[file normalize "$origin_dir/src/vhdl/dvienc_defs.vhdl"]"\
- "[file normalize "$origin_dir/src/vhdl/ddr_out_emard.vhdl"]"\
+ "[file normalize "$origin_dir/src/vhdl/max10.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/keyboard_complex.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/virtual_to_matrix.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/keyboard_to_matrix_wukong.vhdl"]"\
@@ -219,6 +224,7 @@ set files [list \
  "[file normalize "$origin_dir/src/vhdl/termmem.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/lfsr16.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/ram32x1024.vhdl"]"\
+ "[file normalize "$origin_dir/src/vhdl/upscaler_ram32x1024.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/internal1541.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/m6522.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/driverom.vhdl"]"\
@@ -290,6 +296,26 @@ set file "vhdl/hdmi_i2c.vhdl"
 set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
 set_property -name "file_type" -value "VHDL" -objects $file_obj
 
+set file "vhdl/mega65r2_i2c.vhdl"
+set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
+set_property -name "file_type" -value "VHDL" -objects $file_obj
+
+set file "vhdl/mega65r3_i2c.vhdl"
+set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
+set_property -name "file_type" -value "VHDL" -objects $file_obj
+
+set file "vhdl/mega65r4_i2c.vhdl"
+set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
+set_property -name "file_type" -value "VHDL" -objects $file_obj
+
+set file "vhdl/mega65r5_board_i2c.vhdl"
+set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
+set_property -name "file_type" -value "VHDL" -objects $file_obj
+
+set file "vhdl/grove_i2c.vhdl"
+set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
+set_property -name "file_type" -value "VHDL" -objects $file_obj
+
 set file "vhdl/fake_expansion_port.vhdl"
 set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
 set_property -name "file_type" -value "VHDL" -objects $file_obj
@@ -338,11 +364,11 @@ set file "vhdl/rll27_quantise_gaps.vhdl"
 set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
 set_property -name "file_type" -value "VHDL" -objects $file_obj
 
-set file "vhdl/rll27_bits_to_bytes.vhdl"
+set file "vhdl/raw_bits_to_gaps.vhdl"
 set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
 set_property -name "file_type" -value "VHDL" -objects $file_obj
 
-set file "vhdl/raw_bits_to_gaps.vhdl"
+set file "vhdl/rll27_bits_to_gaps.vhdl"
 set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
 set_property -name "file_type" -value "VHDL" -objects $file_obj
 
@@ -358,7 +384,15 @@ set file "vhdl/mfm_gaps.vhdl"
 set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
 set_property -name "file_type" -value "VHDL" -objects $file_obj
 
+set file "vhdl/mfm_bits_to_gaps.vhdl"
+set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
+set_property -name "file_type" -value "VHDL" -objects $file_obj
+
 set file "vhdl/mfm_bits_to_bytes.vhdl"
+set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
+set_property -name "file_type" -value "VHDL" -objects $file_obj
+
+set file "vhdl/ghdl_ram8x2048.vhdl"
 set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
 set_property -name "file_type" -value "VHDL" -objects $file_obj
 
@@ -397,6 +431,18 @@ set_property -name "file_type" -value "VHDL" -objects $file_obj
 set file "vhdl/sid_voice.vhdl"
 set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
 set_property -name "file_type" -value "VHDL" -objects $file_obj
+
+set file "vhdl/sid_tables.vhdl"
+set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
+set_property -name "file_type" -value "VHDL" -objects $file_obj
+
+set file "verilog/sid_voice_8580.v"
+set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
+set_property -name "file_type" -value "Verilog" -objects $file_obj
+
+set file "verilog/sid_envelope.v"
+set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
+set_property -name "file_type" -value "Verilog" -objects $file_obj
 
 set file "vhdl/sid_filters.vhdl"
 set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
@@ -482,7 +528,7 @@ set file "vhdl/sid_6581.vhdl"
 set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
 set_property -name "file_type" -value "VHDL" -objects $file_obj
 
-set file "vhdl/shadowram.vhdl"
+set file "vhdl/shadowram-a100t.vhdl"
 set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
 set_property -name "file_type" -value "VHDL" -objects $file_obj
 
@@ -614,15 +660,31 @@ set file "vhdl/gs4510.vhdl"
 set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
 set_property -name "file_type" -value "VHDL" -objects $file_obj
 
+set file "vhdl/upscaler.vhdl"
+set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
+set_property -name "file_type" -value "VHDL" -objects $file_obj
+
+set file "vhdl/r3_expansion.vhdl"
+set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
+set_property -name "file_type" -value "VHDL" -objects $file_obj
+
+set file "vhdl/neotrng.vhdl"
+set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
+set_property -name "file_type" -value "VHDL" -objects $file_obj
+
 set file "vhdl/fast_divide.vhdl"
 set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
 set_property -name "file_type" -value "VHDL" -objects $file_obj
 
-set file "vhdl/hyperram.vhdl"
+set file "vhdl/sdram.vhdl"
 set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
 set_property -name "file_type" -value "VHDL" -objects $file_obj
 
-set file "vhdl/fakehyperram.vhdl"
+set file "vhdl/sdram_controller.vhdl"
+set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
+set_property -name "file_type" -value "VHDL" -objects $file_obj
+
+set file "vhdl/hyperram.vhdl"
 set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
 set_property -name "file_type" -value "VHDL" -objects $file_obj
 
@@ -662,51 +724,11 @@ set file "vhdl/clocking50mhz.vhdl"
 set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
 set_property -name "file_type" -value "VHDL" -objects $file_obj
 
-set file "vhdl/clock50to100.vhdl"
-set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
-set_property -name "file_type" -value "VHDL" -objects $file_obj
-
 set file "vhdl/wukong.vhdl"
 set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
 set_property -name "file_type" -value "VHDL" -objects $file_obj
 
-set file "vhdl/dvid.vhdl"
-set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
-set_property -name "file_type" -value "VHDL" -objects $file_obj
-
-set file "vhdl/dvid_test.vhdl"
-set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
-set_property -name "file_type" -value "VHDL" -objects $file_obj
-
-set file "vhdl/aux_ecc1.vhdl"
-set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
-set_property -name "file_type" -value "VHDL" -objects $file_obj
-
-set file "vhdl/aux_ecc2.vhdl"
-set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
-set_property -name "file_type" -value "VHDL" -objects $file_obj
-
-set file "vhdl/aux_encoder.vhdl"
-set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
-set_property -name "file_type" -value "VHDL" -objects $file_obj
-
-set file "vhdl/edvi_ucode.vhdl"
-set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
-set_property -name "file_type" -value "VHDL" -objects $file_obj
-
-set file "vhdl/TMDS_encoder.vhdl"
-set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
-set_property -name "file_type" -value "VHDL" -objects $file_obj
-
-set file "vhdl/infoframe_rom_800x600_60hz_40M_48k.vhdl"
-set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
-set_property -name "file_type" -value "VHDL" -objects $file_obj
-
-set file "vhdl/dvienc_defs.vhdl"
-set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
-set_property -name "file_type" -value "VHDL" -objects $file_obj
-
-set file "vhdl/ddr_out_emard.vhdl"
+set file "vhdl/max10.vhdl"
 set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
 set_property -name "file_type" -value "VHDL" -objects $file_obj
 
@@ -751,6 +773,10 @@ set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
 set_property -name "file_type" -value "VHDL" -objects $file_obj
 
 set file "vhdl/ram32x1024.vhdl"
+set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
+set_property -name "file_type" -value "VHDL" -objects $file_obj
+
+set file "vhdl/upscaler_ram32x1024.vhdl"
 set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
 set_property -name "file_type" -value "VHDL" -objects $file_obj
 


### PR DESCRIPTION
This PR introduces various changes and additions to make MEGA65 work on the QMTECH Wukong V2 board. The Wukong top-level VHDL file is based on the latest R6 top-level VHDL file, with all non-supported peripherals removed or disabled. 

Changes outside of the Wukong top-level file have been kept to a minimum, so as not to impact other cores:

- A number of signals related to the Ethernet controller in iomapper.vhdl have been assigned a default value, such that the CPU does not lock up when not generating the Ethernet controller.
- The portb_pins signal has been changed from "in" to "inout" to allow the newly added physical keyboard scanner for Wukong to drain remaining charge on the keyboard pins.
- The 50 MHz versions of the clock and audio clock generation logic have been updated. Since AFAIK at the moment Wukong is the only target using these files, this should not affect any other cores.

Peripherals known to work with this core:

- Physical C64 keyboard attached to the 40-pin user GPIO header (J12).
- Joysticks 1 and 2 attached to the two PMOD ports (wired as for Nexys).
- Internal SD-card.
- Serial monitor.
- HDMI video including sound (sound does not work on all monitors).
- QSPI flash.

Known issues:

- Xanadu assembly demo shows black "barcodes"; not sure if that's supposed to happen.
- Megaflash does not support the QSPI flash device for this board, so the core hangs when going into the flash menu. This will be fixed when branch "782-mflash-lowlevel" is merged into development.
