### PR TITLE
Fix cia-oneshot bug not resetting back to latched value  (#821)

### DIFF
--- a/src/vhdl/cia6526.vhdl
+++ b/src/vhdl/cia6526.vhdl
@@ -534,9 +534,8 @@ begin  -- behavioural
             & std_logic'image(sdr_bit_alternate);
           reg_isr(0) <= '1';
           reg_timera_underflow <= '1';
-          if reg_timera_oneshot='0' then
-            reg_timera <= reg_timera_latch;
-          else
+          reg_timera <= reg_timera_latch;
+          if reg_timera_oneshot='1' then
             reg_timera_start <= '0';
           end if;
           reg_timera_has_ticked <= '0';
@@ -589,10 +588,9 @@ begin  -- behavioural
           -- underflow
           report "CIA" & to_hstring(unit) & " timerb underflow";
           reg_isr(1) <= '1';
-          if reg_timerb_oneshot='0' then
-            report "CIA" & to_hstring(unit) & " timerb set from latch";
-            reg_timerb <= reg_timerb_latch;
-          else
+          report "CIA" & to_hstring(unit) & " timerb set from latch";
+          reg_timerb <= reg_timerb_latch;
+          if reg_timerb_oneshot='1' then
             report "CIA" & to_hstring(unit) & " setting reg_timerb_start to " & std_logic'image(fastio_wdata(0));
             reg_timerb_start <= '0';
           end if;


### PR DESCRIPTION
Quick fix to issue #821, tested on hardware on c64 sea wolf, which was previously running very slow, but now is running at the correct speed.

Also, have tested several other programs on the intro disk, just for assurance that it didn't have any obvious negative impact.