### PR TITLE
Implement HWERRATA maximum value

### DIFF
--- a/iomap.txt
+++ b/iomap.txt
@@ -338,7 +338,7 @@ C65 $D087 FDC:DATA F011 FDC data register (read/write) for accessing the floppy 
 C65 $D088 FDC:CLOCK Set or read the clock pattern to be used when writing address and data marks. Should normally be left $FF
 C65 $D089 FDC:STEP Set or read the track stepping rate in 62.5 microsecond steps (normally 128, i.e., 8 milliseconds).
 C65 $D08A FDC:PCODE (Read only) returns the protection code of the most recently read sector. Was intended for rudimentary copy protection. Not implemented.
-GS $D08F Set/get MISCIO:HWERRATA MEGA65 hardware errata level
+GS $D08F MISCIO:HWERRATA Set/get MEGA65 hardware errata level
 GS $D09B - FSM state of low-level SD controller (DEBUG)
 GS $D09C - Last byte low-level SD controller read from card (DEBUG)
 GS $D09D - FDC-side buffer pointer high bit (DEBUG)

--- a/iomap.txt
+++ b/iomap.txt
@@ -139,7 +139,7 @@ C65 $D030.2 VIC-III:PAL Use PALETTE ROM (0) or RAM (1) entries for colours 0 - 1
 C65 $D030.3 VIC-III:ROM8 Map C65 ROM @ $8000
 C65 $D030.4 VIC-III:ROMA Map C65 ROM @ $A000
 C65 $D030.5 VIC-III:ROMC Map C65 ROM @ $C000
-C65 $D030.6 VIC-III:CROM9 Select between C64 and C65 charset.
+C65 $D030.6 VIC-III:CROM9 Select between C64 and C65 charset (not implemented)
 C65 $D030.7 VIC-III:ROME Map C65 ROM @ $E000
 C64 $D030 SUMMARY: C128 2MHz emulation
 C65 $D030 SUMMARY:VIC-III Control Register A
@@ -282,7 +282,7 @@ GS $D079 VIC-IV:RASCMP Physical raster compare value to be used if FNRSTCMP is c
 GS $D07A.0-2 VIC-IV:RASCMP!MSB Raster compare value MSB
 GS $D07A.3 VIC-IV:SPTR!CONT Continuously monitor sprite pointer, to allow changing sprite data source while a sprite is being drawn
 GS $D07A.4 VIC-IV:CHARY16 Alternate char ROM bank on alternate raster lines in V200
-GS $D07A.5 VIC-IV:NOBUGCOMPAT Disables VIC-III / C65 Bug Compatibility Mode if set
+GS $D07A.5 VIC-IV:NOBUGCOMPAT *DEPRECATED*, use HWERRATA - Disables VIC-III / C65 Bug Compatibility Mode if set
 GS $D07A.6 VIC-IV:EXTIRQS Enable additional IRQ sources, e.g., raster X position.
 GS $D07A.7 VIC-IV:FNRST!CMP Raster compare is in physical rasters if clear, or VIC-II rasters if set
 GS $D07B VIC-IV:DISP!ROWS Number of text rows to display
@@ -338,7 +338,7 @@ C65 $D087 FDC:DATA F011 FDC data register (read/write) for accessing the floppy 
 C65 $D088 FDC:CLOCK Set or read the clock pattern to be used when writing address and data marks. Should normally be left $FF
 C65 $D089 FDC:STEP Set or read the track stepping rate in 62.5 microsecond steps (normally 128, i.e., 8 milliseconds).
 C65 $D08A FDC:PCODE (Read only) returns the protection code of the most recently read sector. Was intended for rudimentary copy protection. Not implemented.
-GS $D08F - Set/get MISCIO:HWERRATA MEGA65 hardware errata level
+GS $D08F Set/get MISCIO:HWERRATA MEGA65 hardware errata level
 GS $D09B - FSM state of low-level SD controller (DEBUG)
 GS $D09C - Last byte low-level SD controller read from card (DEBUG)
 GS $D09D - FDC-side buffer pointer high bit (DEBUG)
@@ -529,8 +529,8 @@ GS $D612.4 UARTMISC:PS2JOY Enable PS/2 / USB keyboard simulated joystick input
 GS $D612.5 UARTMISC:JOYSWAP Exchange joystick ports 1 \& 2
 GS $D612.6 UARTMISC:LJOYA Rotate inputs of joystick A by 180 degrees (for left handed use)
 GS $D612.7 UARTMISC:LJOYB Rotate inputs of joystick B by 180 degrees (for left handed use)
-GS $D613 DEBUG:KEYMATRIXPEEK 8-bit segment of combined keyboard matrix (READ)
-GS $D614 DEBUG:KEYMATRIXSEL Select which 8-bit segment of combined keyboard matrix to read.
+GS $D613 UARTMISC:KEYMATRIXPEEK 8-bit segment of combined keyboard matrix (READ)
+GS $D614 UARTMISC:KEYMATRIXSEL Select which 8-bit segment of combined keyboard matrix to read.
 GS $D615.0-6 UARTMISC:VIRTKEY1 Set to \$7F for no key down, else specify virtual key press.
 GS $D615.7 UARTMISC:OSKEN Enable display of on-screen keyboard composited overlay
 GS $D616.0-6 UARTMISC:VIRTKEY2 Set to \$7F for no key down, else specify 2nd virtual key press.

--- a/src/vhdl/iomapper.vhdl
+++ b/src/vhdl/iomapper.vhdl
@@ -60,9 +60,9 @@ entity iomapper is
         viciv_frame_indicate : in std_logic;
         eth_hyperrupt : out std_logic;
 
-        hw_errata_level : out unsigned(7 downto 0);
-        hw_errata_enable_toggle : in std_logic := '0';
-        hw_errata_disable_toggle : in std_logic := '0';
+        hw_errata_level : inout unsigned(7 downto 0);
+        hw_errata_enable_toggle : in std_logic;
+        hw_errata_disable_toggle : in std_logic;
 
         max10_fpga_date : in unsigned(15 downto 0);
         max10_fpga_commit : in unsigned(31 downto 0);

--- a/src/vhdl/machine.vhdl
+++ b/src/vhdl/machine.vhdl
@@ -513,9 +513,9 @@ architecture Behavioral of machine is
   signal dipsw_read : std_logic_vector(7 downto 0);
   signal dipsw_int : std_logic_vector(7 downto 0);
 
-  signal hw_errata_level : unsigned(7 downto 0);
-  signal hw_errata_enable_toggle : std_logic;
-  signal hw_errata_disable_toggle : std_logic;
+  signal hw_errata_level : unsigned(7 downto 0) := x"00";
+  signal hw_errata_enable_toggle : std_logic := '0';
+  signal hw_errata_disable_toggle : std_logic := '0';
 
   signal pmodb_in_buffer : std_logic_vector(5 downto 0);
   signal pmodb_out_buffer : std_logic_vector(1 downto 0);

--- a/src/vhdl/sdcardio.vhdl
+++ b/src/vhdl/sdcardio.vhdl
@@ -1259,7 +1259,7 @@ begin  -- behavioural
             -- Register $D07A.5 VIC-IV:NOBUGCOMPAT will set this to 0 or hw_errata_level_max!
             -- There is no feedback from this register back to NOBUGCOMPAT!
             --
-            -- TODO: please document new errate levels here, and please **also** add HWERRATA:LEVEL where you use it!
+            -- TODO: please document new errata levels here, and please **also** add HWERRATA:LEVEL where you use it!
             -- TODO: if adding a new level, remember to raise hw_errata_level_max constant!
             --
             -- HWERRATA Table:

--- a/src/vhdl/sdcardio.vhdl
+++ b/src/vhdl/sdcardio.vhdl
@@ -1759,24 +1759,13 @@ begin  -- behavioural
 
     if rising_edge(clock) then
 
+      -- backwards compability to $D07A.5 VIC-IV:NOBUGCOMPAT
       if hw_errata_enable_toggle /= hw_errata_enable_toggle_last then
         hw_errata_enable_toggle_last <= hw_errata_enable_toggle;
         hw_errata_level_int <= x"ff";
         hw_errata_level <= x"ff";
       end if;
 
-      if hw_errata_disable_toggle /= hw_errata_disable_toggle_last then
-        hw_errata_disable_toggle_last <= hw_errata_disable_toggle;
-        hw_errata_level_int <= x"00";
-        hw_errata_level <= x"00";
-      end if;
-
-      if hw_errata_enable_toggle /= hw_errata_enable_toggle_last then
-        hw_errata_enable_toggle_last <= hw_errata_enable_toggle;
-        hw_errata_level_int <= x"ff";
-        hw_errata_level <= x"ff";
-      end if;
-      
       if hw_errata_disable_toggle /= hw_errata_disable_toggle_last then
         hw_errata_disable_toggle_last <= hw_errata_disable_toggle;
         hw_errata_level_int <= x"00";

--- a/src/vhdl/sdcardio.vhdl
+++ b/src/vhdl/sdcardio.vhdl
@@ -1253,7 +1253,7 @@ begin  -- behavioural
             -- P CODE  |  P7   |  P6   |  P5   |  P4   |  P3   |  P2   |  P1   |  P0   | A R
             fastio_rdata <= f011_reg_pcode;
           when "01111" =>
-            -- @IO:GS $D08F Set/get MISCIO:HWERRATA MEGA65 hardware errata level
+            -- @IO:GS $D08F MISCIO:HWERRATA Set/get MEGA65 hardware errata level
             --
             -- Register $D07A.5 VIC-IV:NOBUGCOMPAT will set this to 0 or hw_errata_level_max!
             -- There is no feedback from this register back to NOBUGCOMPAT!

--- a/src/vhdl/sdcardio.vhdl
+++ b/src/vhdl/sdcardio.vhdl
@@ -1259,13 +1259,13 @@ begin  -- behavioural
             -- Register $D07A.5 VIC-IV:NOBUGCOMPAT will set this to 0 or hw_errata_level_max!
             -- There is no feedback from this register back to NOBUGCOMPAT!
             --
-            -- TODO: please document new errate levels here, please add HWERRATA:LEVEL where you use it!
+            -- TODO: please document new errate levels here, and please **also** add HWERRATA:LEVEL where you use it!
             -- TODO: if adding a new level, remember to raise hw_errata_level_max constant!
             --
             -- HWERRATA Table:
-            -- 1 - VIC-IV XSCL position shifted in H640 mode.
-            -- 2 - VIC-IV Character attribute combinations.
-            -- !!not merged!! 3 - SDCARD SD Card Busy Flag behaviour.
+            -- HWERRATA:1 - VIC-IV XSCL position shifted in H640 mode.
+            -- HWERRATA:2 - VIC-IV Character attribute combinations.
+            -- !!not merged!! HWERRATA:3 - SDCARD SD Card Busy Flag behaviour.
             --
             fastio_rdata <= hw_errata_level_int;
           when "11011" => -- @IO:GS $D09B - FSM state of low-level SD controller (DEBUG)

--- a/src/vhdl/sdcardio.vhdl
+++ b/src/vhdl/sdcardio.vhdl
@@ -1265,7 +1265,6 @@ begin  -- behavioural
             -- HWERRATA Table:
             -- HWERRATA:1 - VIC-IV XSCL position shifted in H640 mode.
             -- HWERRATA:2 - VIC-IV Character attribute combinations.
-            -- !!not merged!! HWERRATA:3 - SDCARD SD Card Busy Flag behaviour.
             --
             fastio_rdata <= hw_errata_level_int;
           when "11011" => -- @IO:GS $D09B - FSM state of low-level SD controller (DEBUG)

--- a/src/vhdl/viciv.vhdl
+++ b/src/vhdl/viciv.vhdl
@@ -63,8 +63,8 @@ entity viciv is
     hypervisor_mode : in std_logic;
 
     hw_errata_level : in unsigned(7 downto 0);
-    hw_errata_enable_toggle : inout std_logic := '0';
-    hw_errata_disable_toggle : inout std_logic := '0';
+    hw_errata_enable_toggle : inout std_logic;
+    hw_errata_disable_toggle : inout std_logic;
 
     xcounter_out : out integer range 0 to 4095 := 0;
     ycounter_out : out integer range 0 to 2047 := 0;

--- a/src/vhdl/viciv.vhdl
+++ b/src/vhdl/viciv.vhdl
@@ -2924,7 +2924,7 @@ begin
           -- @IO:GS $D07A.0-2 VIC-IV:RASCMP!MSB Raster compare value MSB
           -- @IO:GS $D07A.3 VIC-IV:SPTR!CONT Continuously monitor sprite pointer, to allow changing sprite data source while a sprite is being drawn
           -- @IO:GS $D07A.4 VIC-IV:CHARY16 Alternate char ROM bank on alternate raster lines in V200
-          -- @IO:GS $D07A.5 VIC-IV:NOBUGCOMPAT Disables VIC-III / C65 Bug Compatibility Mode if set (changes HWERRATA level)
+          -- @IO:GS $D07A.5 VIC-IV:NOBUGCOMPAT *DEPRECATED*, use HWERRATA - Disables VIC-III / C65 Bug Compatibility Mode if set
           -- @IO:GS $D07A.6 VIC-IV:EXTIRQS Enable additional IRQ sources, e.g., raster X position.
           -- @IO:GS $D07A.7 VIC-IV:FNRST!CMP Raster compare is in physical rasters if clear, or VIC-II rasters if set
           irq_extras_enable <= fastio_wdata(6);

--- a/src/vhdl/viciv.vhdl
+++ b/src/vhdl/viciv.vhdl
@@ -2091,7 +2091,7 @@ begin
         prev_hw_errata_level <= hw_errata_level;
 
         -- Apply variable HW errata level settings
-        -- Level 1: VIC-III D016 Delta
+        -- HWERRATA:1 VIC-III D016 Delta
         if to_integer(hw_errata_level) > 0 then
           bug_compat_vic_iii_d016_delta <= 0;
           bug_compat_mode <= '0';
@@ -2099,7 +2099,7 @@ begin
           bug_compat_vic_iii_d016_delta <= 2;
           bug_compat_mode <= '1';
         end if;
-        -- Level 2: Character attribute fixes
+        -- HWERRATA:2 Character attribute fixes
         if to_integer(hw_errata_level) > 1 then
           bug_compat_char_attr <= '0';
         else
@@ -2924,7 +2924,7 @@ begin
           -- @IO:GS $D07A.0-2 VIC-IV:RASCMP!MSB Raster compare value MSB
           -- @IO:GS $D07A.3 VIC-IV:SPTR!CONT Continuously monitor sprite pointer, to allow changing sprite data source while a sprite is being drawn
           -- @IO:GS $D07A.4 VIC-IV:CHARY16 Alternate char ROM bank on alternate raster lines in V200
-          -- @IO:GS $D07A.5 VIC-IV:NOBUGCOMPAT Disables VIC-III / C65 Bug Compatibility Mode if set
+          -- @IO:GS $D07A.5 VIC-IV:NOBUGCOMPAT Disables VIC-III / C65 Bug Compatibility Mode if set (changes HWERRATA level)
           -- @IO:GS $D07A.6 VIC-IV:EXTIRQS Enable additional IRQ sources, e.g., raster X position.
           -- @IO:GS $D07A.7 VIC-IV:FNRST!CMP Raster compare is in physical rasters if clear, or VIC-II rasters if set
           irq_extras_enable <= fastio_wdata(6);


### PR DESCRIPTION
This implements #829 by limiting the value written to the register to the maximum the core supports. The VIC NOBUGCOMPAT bit will set to the highest supported level or reset to 0.