### PR TITLE
[MEGAFLASH] CRC check fix for attic-less boards; a minor fix and an addition for the Wukong board

### DIFF
--- a/src/utilities/megaflash/s25flxxxs.h
+++ b/src/utilities/megaflash/s25flxxxs.h
@@ -3,7 +3,4 @@
 
 extern void * const s25flxxxs;
 
-// char write_dynamic_protection_bits(unsigned int sector_number, BOOL protect);
-char write_dynamic_protection_bits(unsigned long address, BOOL protect);
-
 #endif

--- a/src/vhdl/wukong.vhdl
+++ b/src/vhdl/wukong.vhdl
@@ -36,8 +36,9 @@ entity container is
     reset_button : in std_logic;
 
     -- Keyboard.
-    porta_pins : inout std_logic_vector(7 downto 0);
-    portb_pins : inout std_logic_vector(7 downto 0);
+    restore_key : in std_logic;
+    porta_pins  : inout std_logic_vector(7 downto 0);
+    portb_pins  : inout std_logic_vector(7 downto 0);
 
     -- Joysticks.
     fa_left  : in std_logic;
@@ -86,7 +87,6 @@ architecture Behavioral of container is
   signal pixelclock           : std_logic;
   signal clock27              : std_logic;
   signal clock270             : std_logic;
-  signal restore_key          : std_logic := '1';
   signal sector_buffer_mapped : std_logic;
   signal fpga_temperature     : std_logic_vector(11 downto 0) := (others => '0');
 

--- a/src/vhdl/wukong.xdc
+++ b/src/vhdl/wukong.xdc
@@ -39,7 +39,7 @@ set_property -dict {PACKAGE_PIN P18 IOSTANDARD LVCMOS33                } [get_po
 # Buttons.
 ################################################################################
 set_property -dict {PACKAGE_PIN H7  IOSTANDARD LVCMOS33} [get_ports reset_button];
-#set_property -dict {PACKAGE_PIN M6  IOSTANDARD LVCMOS33} [get_ports button2     ];
+set_property -dict {PACKAGE_PIN M6  IOSTANDARD LVCMOS33} [get_ports restore_key ];
 
 ################################################################################
 # LEDs.

--- a/vivado/wukong_gen.tcl
+++ b/vivado/wukong_gen.tcl
@@ -132,7 +132,7 @@ set files [list \
  "[file normalize "$origin_dir/src/vhdl/uart_rx_buffered.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/buffereduart.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/sid_6581.vhdl"]"\
- "[file normalize "$origin_dir/src/vhdl/shadowram-a100t.vhdl"]"\
+ "[file normalize "$origin_dir/src/vhdl/shadowram-s25flxlno.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/sdcardio.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/audio_mixer.vhdl"]"\
  "[file normalize "$origin_dir/src/vhdl/audio_complex.vhdl"]"\
@@ -528,7 +528,7 @@ set file "vhdl/sid_6581.vhdl"
 set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
 set_property -name "file_type" -value "VHDL" -objects $file_obj
 
-set file "vhdl/shadowram-a100t.vhdl"
+set file "vhdl/shadowram-s25flxlno.vhdl"
 set file_obj [get_files -of_objects [get_filesets sources_1] [list "*$file"]]
 set_property -name "file_type" -value "VHDL" -objects $file_obj
 


### PR DESCRIPTION
This pull request contains:

* A fix for the CRC check in megaflash for all boards without attic RAM.
* A fix for the generated Vivado project file for the Wukong board to include the correct shadow ram file.
* Support for using the second user button on the Wukong board as an alternative Restore key.
* Remove file static (internal) function from header file.
