### PR TITLE
HYPPO: Add freeze region for the rest of FDD3000

### DIFF
--- a/src/hyppo/freeze.asm
+++ b/src/hyppo/freeze.asm
@@ -1147,6 +1147,12 @@ freeze_mem_list:
         !8 0
         !8 freeze_prep_none
 
+        ;; The reset of FFD3000 from last track (for drive initialization)
+        !32 $ffd3084
+        !16 $007C
+        !8 0
+        !8 freeze_prep_none
+
         ;; XXX - Other IO chips!
 
         ;; End of list


### PR DESCRIPTION
Fixes https://github.com/MEGA65/mega65-core/issues/868

In https://github.com/MEGA65/mega65-core/pull/755 I reduced the amount of memory saved in the FFD3000 region to avoid unfreezing into D081. I should have added another region to save the rest of that region (starting with last accessed track at D084).

Not saving D084 causes the mounting of the internal drive to seek the head to track 0x55 instead of the correct location. 0x55 being the value returned for peeks into the frozen memory that were not saved.