### PR TITLE
Lengthen the keyboard debounce timer based on user reports of double-strikes

### DIFF
--- a/src/vhdl/matrix_to_ascii.vhdl
+++ b/src/vhdl/matrix_to_ascii.vhdl
@@ -856,7 +856,9 @@ architecture behavioral of matrix_to_ascii is
   signal prev_key_num : integer range 0 to 71 := 0;
   signal key_num_timeout : integer := 0;
   -- Cherry key switches claim a 5 ms debounce time = 1/200th of clock frequency
-  constant cherry_mx_debounce_time : integer := clock_frequency / 1000;
+  -- Using a longer delay based on user reports of occasional unintentional
+  -- double-strikes:
+  constant cherry_mx_debounce_time : integer := clock_frequency / 2500;
 
 begin
 


### PR DESCRIPTION
Lengthen the keyboard debounce timer based on user reports of double-strikes.

I have tested this change with one affected user and they report the issue subsides. I was not able to reproduce debounce double-strikes before or after this change on my own hardware, but I also don't notice a difference with this change.

Fixes https://github.com/MEGA65/mega65-core/issues/870