### PR TITLE
Fix inaccurate CIA timing in NTSC

### DIFF
--- a/src/vhdl/pixel_driver.vhdl
+++ b/src/vhdl/pixel_driver.vhdl
@@ -666,7 +666,12 @@ begin
                   last_raster => 480 - debug_height_reduction,
 
                   lcd_first_raster => 1,
-                  lcd_last_raster => 480 - debug_height_reduction
+                  lcd_last_raster => 480 - debug_height_reduction,
+
+                  cycles_per_raster_1mhz => 65,
+                  cycles_per_raster_2mhz => 65*2,
+                  cycles_per_raster_3mhz => 228 -- 65*3.5, rounded up to next integer
+                  
                   )                  
     port map ( clock81 => clock81,
                clock41 => cpuclock,


### PR DESCRIPTION
Now correctly counting 65 cycles per VIC-II raster instead of 63.
Fixing issue #816 

The frame_generator is by default configured to count 63 cycles per VIC-II raster. In case NTSC is used (D06F.7 and D06F.6 both clear), the default was not overridden with the correct NTSC cycle count (65). The PR aims to correct that. This should bring both the 1MHz CPU speed and the CIA timing in NTSC very close to the original C64 timing.