### PR TITLE
Fix "INQ crash"

### DIFF
--- a/src/vhdl/gs4510.vhdl
+++ b/src/vhdl/gs4510.vhdl
@@ -8218,7 +8218,13 @@ begin
               -- reg_q33 holds the q reg, no need to load anything
               next_is_axyz32_instruction <= '0';
               report "ExecuteQreg32: reg_q33 = $" & to_hstring(reg_q33) & ", reg_instruction = " & instruction'image(reg_instruction);
-              pc_inc := '1';
+              if fast_fetch_state = InstructionDecode then
+                pc_inc := '1';
+              else
+                report "not setting pc_inc, because fast_fetch_state /= InstructionDecode";
+                pc_inc := '0';
+              end if;
+              -- pc_inc := '1';
               pc_dec := '0';
               case reg_instruction is
                 when I_INC =>


### PR DESCRIPTION
`ExecuteQreg32` instructions now check if `fast_fetch_state` is `InstructionDecode` before incrementing the PC. This prevents the PC from incrementing in situations where the CPU should be paused, such as when the matrix monitor is reading memory.