### PR TITLE
Take the freeze slot number in the byte order the code actually uses

### DIFF
--- a/src/hyppo/syspart.asm
+++ b/src/hyppo/syspart.asm
@@ -237,6 +237,8 @@ syspart_configsector_apply_trap:
         sta hypervisor_enterexit_trigger
 
 syspart_unfreeze_from_slot_trap:
+        ;; Only X needs restoring: the dispatch above clobbers it with tax,
+        ;; while Y arrives from the caller untouched.
         ldx hypervisor_x
         jsr syspart_locate_freezeslot
         jsr unfreeze_load_from_sdcard_immediate
@@ -278,8 +280,13 @@ syspart_locate_freezeslot_trap:
 
 syspart_locate_freezeslot:
         ;; Get the first sector of a given freeze slot
-        ;; X = low byte of slot #
-        ;; Y = high byte of slot #
+        ;; X = high byte of slot #
+        ;; Y = low byte of slot #
+        ;;
+        ;; The slot number is pushed here and popped back below in the same
+        ;; order, which swaps the pair: plx takes what phy pushed.  So the
+        ;; multiply reads its low byte from Y, and freeze_to_slot in freeze.asm
+        ;; documents the same order ("Slot in XXYY").
 
         phx
         phy
@@ -288,21 +295,25 @@ syspart_locate_freezeslot:
         lda syspart_present
         bne splf1
         lda #syspart_error_nosyspart
-        sta syspart_error_code
-        clc
-        rts
+        bra slotfail
 splf1:
-        ;; Check that freeze slot number is not invalid
-        cpy syspart_freeze_slot_count+1
-        beq sc1
+        ;; Check that freeze slot number is not invalid.
+        ;; High byte first; only when it matches does the low byte decide.
+        cpx syspart_freeze_slot_count+1
         bcc slotnumok
-sc1:        cpx syspart_freeze_slot_count+0
-        beq slotbad
+        bne slotbad
+        cpy syspart_freeze_slot_count+0
         bcc slotnumok
 slotbad:
         ;; Report error status for out of bounds slot number
         lda #syspart_error_badslotnum
+slotfail:
+        ;; Both error paths leave through here, because the slot number is
+        ;; still on the stack from the phx/phy above and returning without it
+        ;; would take the caller's return address with it.
         sta syspart_error_code
+        plx
+        plx
         clc
         rts
 


### PR DESCRIPTION
`syspart_locate_freezeslot` says X holds the low byte of the slot number and Y the high byte. It does the opposite and pushes X then Y, and pops with plx before ply, so plx gets what phy pushed. The multiply reads the low byte from Y.

`freeze_to_slot` in `freeze.asm` already does it correctly, asking for "Slot in XXYY".

Callers have followed the code, not the comment: the cc65 freeze menu carries _;; XXX - We had to swap the X/Y byte order around for this to work: Why???._ This changes the comment and  bounds check only as swapping the pops would break every caller that works today.

Measured on an R3 with 1888 slots, and under Xemu with 2045: a slot passed the documented way lands 256 slots on. Slot 1 gave base + $40000 where the slot size is $400.

### Other fixes:

- Bounds check never rejected anything. After comparing the high byte it fell through into the low byte comparison whichever way the first test went, so the high byte's answer was thrown away. An out-of-range slot was accepted and returned a sector past the end of the slot area. Under Xemu, slot 2145 of 2045 was accepted before this change and is refused after; slots 0 and 1 are unchanged.

- Both error paths returned without pulling the slot number the routine had pushed, so rts took the caller's return address off the stack instead. Nothing triggered it, because the check accepted everything. Fixing the check hung the machine until this was fixed too.

 - `syspart_unfreeze_from_slot_trap` deliberately restores only X. The dispatch clobbers X with tax, while Y reaches the handler from the caller untouched. TrapToHypervisor in gs4510.vhdl copies registers to the shadow set and assigns only reg_sp, reg_sph and the flags — never reg_y.

Tested by assembling HICKUP and running it under Xemu with -hickup, reading the sector back from $D681 for slots 0, 1 and one past the end.
